### PR TITLE
fix: 让 SSE 翻译器在异常退出时不再误伤流控制器

### DIFF
--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -323,6 +323,15 @@ function peekBody(body: string | undefined): RequestMeta {
 let reqCounter = 0;
 let headerPrinted = false;
 
+/** Format a unix-ms timestamp as local HH:MM:SS in the host's timezone (not UTC). */
+function localTime(ms: number): string {
+  const d = new Date(ms);
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  const ss = String(d.getSeconds()).padStart(2, "0");
+  return `${hh}:${mm}:${ss}`;
+}
+
 function nextReqId(): string {
   return `#${String(++reqCounter).padStart(3, "0")}`;
 }
@@ -350,7 +359,7 @@ function printRow(
   streamEndAt: number,
 ): void {
   printHeader();
-  const ts = new Date(started).toISOString().slice(11, 19);
+  const ts = localTime(started);
   const tag = format === "anthropic" ? "ANT" : "OAI";
   const mode = meta.stream ? "stream" : "batch";
   const ttfb = `${headersAt - started}ms`;

--- a/src/translator/sse-translator.ts
+++ b/src/translator/sse-translator.ts
@@ -95,6 +95,7 @@ export function anthropicSseToOpenaiSse(
   return new ReadableStream({
     async start(controller) {
       const reader = upstream.getReader();
+      let errored = false;
 
       try {
         while (true) {
@@ -128,9 +129,13 @@ export function anthropicSseToOpenaiSse(
         // Emit [DONE]
         controller.enqueue(encoder.encode("data: [DONE]\n\n"));
       } catch (err) {
-        controller.error(err);
+        errored = true;
+        // error()/close() 互斥:errored 流上再 close() 会抛 TypeError,进而触发 Bun 引擎空指针崩溃。
+        try { controller.error(err); } catch {}
       } finally {
-        controller.close();
+        if (!errored) {
+          try { controller.close(); } catch {}
+        }
         reader.releaseLock();
       }
     },
@@ -232,6 +237,7 @@ export function openaiSseToAnthropicSse(
   return new ReadableStream({
     async start(controller) {
       const reader = upstream.getReader();
+      let errored = false;
 
       try {
         while (true) {
@@ -306,9 +312,13 @@ export function openaiSseToAnthropicSse(
           }
         }
       } catch (err) {
-        controller.error(err);
+        errored = true;
+        // error()/close() 互斥:errored 流上再 close() 会抛 TypeError,进而触发 Bun 引擎空指针崩溃。
+        try { controller.error(err); } catch {}
       } finally {
-        controller.close();
+        if (!errored) {
+          try { controller.close(); } catch {}
+        }
         reader.releaseLock();
       }
     },


### PR DESCRIPTION
controller.error() 会让流进入 errored 状态，finally 再调用 controller.close() 违反 WHATWG 规范、必抛 TypeError。该异常在 async start 中无人捕获，触发 Bun 引擎内部回调访问已被置空的控制器，最终以 "TypeError: null is not an object" 拖垮整个进程。仅当流式翻译被上游或客户端中断时才走进 catch，故表现为偶发崩溃。

- 引入 errored 标志位，使 error()/close() 互斥
- 对两处 controller 操作再加防御性 try-catch，规避流已取消场景下的边角抛错

Fixes #7 