### PR TITLE
fix(proxy): align upstream headers & identity with ZCode 3.1.5

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -54,8 +54,8 @@ models:
 identity:
   # Mirrors process.env.ZCODE_APP_VERSION in the ZCode bundle.
   # Must be printable ASCII; non-conforming values fall back to the default.
-  # Default: "3.1.1" (current ZCode release). Override to match your real client.
-  appVersion: "3.1.1"
+  # Default: "3.1.5" (current ZCode release). Override to match your real client.
+  appVersion: "3.1.5"
   # X-Title suffix → "Z Code@{sourceTitle}". Default "cli".
   sourceTitle: "cli"
   # HTTP-Referer URL. Default "https://zcode.z.ai".

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -162,7 +162,7 @@ auth:
   apiKey: "abc"
 `);
     const cfg = loadConfig(path);
-    expect(cfg.identity.appVersion).toBe("3.1.1");
+    expect(cfg.identity.appVersion).toBe("3.1.5");
     expect(cfg.identity.sourceTitle).toBe("cli");
     expect(cfg.identity.refererOrigin).toBe("https://zcode.z.ai");
   });
@@ -202,9 +202,9 @@ auth:
   mode: apikey
   apiKey: "abc"
 identity:
-  appVersion: "v3.1.1-中文"
+  appVersion: "v3.1.5-中文"
 `);
     const cfg = loadConfig(path);
-    expect(cfg.identity.appVersion).toBe("3.1.1");
+    expect(cfg.identity.appVersion).toBe("3.1.5");
   });
 });

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -28,7 +28,7 @@ const DEFAULTS = {
   ZAI_OPENAI_BASE: "https://api.z.ai/api/coding/paas/v4",
   BIGMODEL_ANTHROPIC_BASE: "https://open.bigmodel.cn/api/anthropic",
   BIGMODEL_OPENAI_BASE: "https://open.bigmodel.cn/api/coding/paas/v4",
-  APP_VERSION: "3.1.1",
+  APP_VERSION: "3.1.5",
   SOURCE_TITLE: "cli",
   REFERER_ORIGIN: "https://zcode.z.ai",
 };

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -30,13 +30,13 @@ interface AuthConfig {
 
 /**
  * Identity headers injected on every upstream request to mimic the ZCode
- * desktop client. Mirrors the `eYn` builder in the reverse-engineered bundle
+ * desktop client. Mirrors the `pio` builder in the reverse-engineered bundle
  * (`_reverse/zcode.cjs`); see `_reverse/NOTEPAD.md` "How Credential is Used".
  *
  * Resolution: env var (matches ZCode's own convention) → YAML override → default.
  * `appVersion` must be printable ASCII (`/^[\x20-\x7e]+$/`); non-conforming
  * values are silently dropped and fall back to the default (current ZCode
- * release), exactly like `rYn` in the bundle.
+ * release), exactly like `fio` in the bundle.
  */
 export interface ProxyIdentity {
   appVersion: string;

--- a/src/proxy/identity.test.ts
+++ b/src/proxy/identity.test.ts
@@ -1,5 +1,6 @@
 /**
  * Tests for identity header builder.
+ * Mirrors `pio` in the current ZCode bundle (`_reverse/zcode.cjs`).
  * @see _reverse/NOTEPAD.md "How Credential is Used for LLM Calls"
  */
 import { describe, it, expect } from "bun:test";
@@ -39,9 +40,34 @@ describe("buildIdentityHeaders", () => {
     expect(h["HTTP-Referer"]).toBe("https://example.com");
   });
 
-  it("preserves the 'unknown' fallback literally (loader-level concern)", () => {
+  it("preserves the literal 'unknown' version (still printable ASCII)", () => {
     const h = buildIdentityHeaders({ ...BASE, appVersion: "unknown" });
     expect(h["User-Agent"]).toBe("ZCode/unknown");
     expect(h["X-ZCode-App-Version"]).toBe("unknown");
+  });
+
+  // --- New behaviour matching `pio` in the current ZCode bundle ---
+
+  it("emits headers in the exact `pio` order", () => {
+    const h = buildIdentityHeaders(BASE);
+    // Mirrors the bundle: HTTP-Referer → User-Agent → X-ZCode-App-Version → X-Title → X-ZCode-Agent
+    expect(Object.keys(h)).toEqual([
+      "HTTP-Referer",
+      "User-Agent",
+      "X-ZCode-App-Version",
+      "X-Title",
+      "X-ZCode-Agent",
+    ]);
+  });
+
+  it("drops X-ZCode-App-Version and falls User-Agent back to ZCode/unknown when no version resolves", () => {
+    // Mirrors `pio` when `fio` returns undefined: User-Agent → "ZCode/unknown", no X-ZCode-App-Version.
+    const empty = buildIdentityHeaders({ ...BASE, appVersion: "" });
+    expect(empty["User-Agent"]).toBe("ZCode/unknown");
+    expect(empty["X-ZCode-App-Version"]).toBeUndefined();
+
+    const missing = buildIdentityHeaders({ ...BASE, appVersion: undefined as unknown as string });
+    expect(missing["User-Agent"]).toBe("ZCode/unknown");
+    expect(missing["X-ZCode-App-Version"]).toBeUndefined();
   });
 });

--- a/src/proxy/identity.ts
+++ b/src/proxy/identity.ts
@@ -3,31 +3,56 @@
  * on every upstream request so the proxy is indistinguishable from the official
  * client at the fingerprinting layer.
  *
- * Mirrors `eYn` in `_reverse/zcode.cjs` (offset ~9074294). Differences from the
- * bundle: we read resolved values from `ProxyIdentity` (env/YAML already merged
- * by the config loader) instead of `e[art]`/`t.appVersion`, and we always emit
- * `X-ZCode-App-Version` rather than gating on truthiness — the loader guarantees
- * a printable-ASCII value or the default (`3.1.1`, the current ZCode release).
+ * Mirrors `pio` in the current ZCode bundle (`_reverse/zcode.cjs`, the
+ * `buildProviderIdentityHeaders` helper). Field-for-field, order-for-order:
+ *
+ *   {
+ *     "HTTP-Referer":        EP(env)            // refererOrigin (prod default https://zcode.z.ai)
+ *     "User-Agent":          `ZCode/${n ?? "unknown"}`
+ *     "X-ZCode-App-Version": n                  // ONLY when a valid version resolves
+ *     "X-Title":             `Z Code@${sourceTitle}`
+ *     "X-ZCode-Agent":       "glm"
+ *   }
+ *
+ * where `n = fio(...)` is the resolved appVersion, validated against
+ * `/^[\x20-\x7e]+$/` (printable ASCII). When no version resolves, `pio` drops
+ * `X-ZCode-App-Version` entirely and falls back the User-Agent to
+ * `ZCode/unknown`. We replicate both behaviours exactly.
+ *
+ * We read resolved values from `ProxyIdentity` (env/YAML already merged by the
+ * config loader, which mirrors `fio`'s ASCII gate). `sourceTitle` maps to
+ * `t.sourceTitle ?? hio()` in the bundle (`hio()` yields "electron" under the
+ * Electron app-server argv, else "cli"); the loader default is "cli".
  *
  * @see _reverse/NOTEPAD.md "How Credential is Used for LLM Calls"
  */
 import type { ProxyIdentity } from "../config/types.js";
 
-interface IdentityHeaders {
-  "User-Agent": string;
-  "X-ZCode-App-Version": string;
-  "X-Title": string;
-  "X-ZCode-Agent": "glm";
-  "HTTP-Referer": string;
+/** Printable-ASCII gate copied from the ZCode bundle's `fio` helper. */
+const ASCII_PRINTABLE = /^[\x20-\x7e]+$/;
+
+/** Resolve the appVersion the way `fio` does: trimmed + printable ASCII, else undefined. */
+function resolveAppVersion(raw: string | undefined): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  const v = raw.trim();
+  return v.length > 0 && ASCII_PRINTABLE.test(v) ? v : undefined;
 }
 
-/** Build the five identity headers injected upstream. Pure function. */
-export function buildIdentityHeaders(id: ProxyIdentity): IdentityHeaders {
-  return {
-    "User-Agent": `ZCode/${id.appVersion}`,
-    "X-ZCode-App-Version": id.appVersion,
+/**
+ * Build the five identity headers injected upstream, in the exact order and with
+ * the exact conditional semantics of the bundle's `pio`. Pure function.
+ *
+ * Returns `Record<string, string>` rather than a fixed interface because
+ * `X-ZCode-App-Version` is conditionally omitted (matching `pio`).
+ */
+export function buildIdentityHeaders(id: ProxyIdentity): Record<string, string> {
+  const n = resolveAppVersion(id.appVersion);
+  const headers: Record<string, string> = {
+    "HTTP-Referer": id.refererOrigin,
+    "User-Agent": `ZCode/${n ?? "unknown"}`,
+    ...(n ? { "X-ZCode-App-Version": n } : {}),
     "X-Title": `Z Code@${id.sourceTitle}`,
     "X-ZCode-Agent": "glm",
-    "HTTP-Referer": id.refererOrigin,
   };
+  return headers;
 }

--- a/src/proxy/upstream.ts
+++ b/src/proxy/upstream.ts
@@ -63,6 +63,14 @@ export function buildUpstreamURL(format: Format, provider: ProviderDef, plan: "c
  * - Anthropic upstream, start-plan  → `Authorization: Bearer {jwt}` + `anthropic-version`
  * - OpenAI upstream (coding-plan)   → `Authorization: Bearer {cred}`
  *
+ * Trace/attribution headers mirror the bundle's `wdt`
+ * ("createModelRequestAttributionHeaders"). That helper emits `x-request-id`
+ * and `x-zcode-trace-id` unconditionally, and `x-query-id` / `x-session-id`
+ * only when those IDs exist — with their internal prefixes stripped
+ * (`query_`, `sess_`, `subagent_agent_`), so the wire values are bare UUIDs.
+ * The proxy has no session lifecycle, so it always synthesizes fresh bare UUIDs
+ * for all four (matching what a live ZCode turn sends on the wire).
+ *
  * See module header for translation semantics.
  */
 export function buildAuthHeaders(format: Format, cred: Credential, identity: ProxyIdentity, plan: "coding-plan" | "start-plan" = "coding-plan"): Record<string, string> {
@@ -71,7 +79,8 @@ export function buildAuthHeaders(format: Format, cred: Credential, identity: Pro
     ...buildIdentityHeaders(identity),
     "x-request-id": crypto.randomUUID(),
     "x-zcode-trace-id": crypto.randomUUID(),
-    "x-query-id": `query_${crypto.randomUUID()}`,
+    // `wdt` strips the `query_` / `sess_` internal prefixes — wire values are bare UUIDs.
+    "x-query-id": crypto.randomUUID(),
     "x-session-id": crypto.randomUUID(),
   };
 


### PR DESCRIPTION
## Summary

Re-extracted the request shape from the **current** ZCode desktop bundle (v3.1.5, 2026-06 build, `resources/glm/zcode.cjs`) and aligned the proxy so its upstream headers / identity are field-for-field identical to the official client. ZCode changed its request construction in the latest release; this brings the proxy back in sync.

## What changed

**Identity headers (`src/proxy/identity.ts`)** — now mirror the bundle's `pio` builder exactly:
- Correct field order: `HTTP-Referer` → `User-Agent` → `X-ZCode-App-Version` → `X-Title` → `X-ZCode-Agent`
- `X-ZCode-App-Version` is now **conditional** (only emitted when a valid version resolves), matching `pio`/`fio`
- `User-Agent` falls back to `ZCode/unknown` when no version resolves (was always emitting the version)

**Trace/attribution headers (`src/proxy/upstream.ts`)** — mirror the bundle's `wdt` (`createModelRequestAttributionHeaders`):
- Removed the leaked `query_` prefix on `x-query-id`. The bundle's `wdt` strips `query_` / `sess_` / `subagent_agent_` internal prefixes, so the on-the-wire values are **bare UUIDs**. The proxy was sending `x-query-id: query_<uuid>` (with prefix) — now bare, matching ZCode.

**Version bump** — default `appVersion` `3.1.1` → `3.1.5` (the installed ZCode release's `ProductVersion`).

## Verified unchanged (already matches the current bundle)

The request **body construction** and **system prompt** were checked field-for-field against `zcode.cjs` and already match — no change needed:
- `stream_options.include_usage` (OpenAI streaming) — matches `doStream`
- `metadata.user_id` injection (Anthropic) — matches the body builder
- `cache_control` finalize on the last non-system message — matches `YQr` (`finalizeLatestNonSystemMessageCacheControl`)
- Start-plan system blocks (`zcode_system.json`) — match `UZr` (CLI prefix) + `FZr` (agent identity)
- `HTTP-Referer` default `https://zcode.z.ai` — matches `EP`/`V8r`

## Testing

- Full test suite passes: **217 pass / 0 fail** (including new tests for `pio` ordering + conditional `X-ZCode-App-Version`)
- Live end-to-end against `api.z.ai` with a real coding-plan key — all four paths return `200`:
  - Anthropic batch ✓
  - Anthropic stream ✓
  - OpenAI→Anthropic translation batch ✓
  - OpenAI→Anthropic translation stream ✓

Debug trace confirms the corrected upstream headers:
```
user-agent=ZCode/3.1.5
x-zcode-app-version=3.1.5
x-query-id=<bare-uuid>          # no query_ prefix
x-request-id / x-zcode-trace-id / x-session-id = <bare-uuid>
http-referer=https://zcode.z.ai
x-title=Z Code@cli
x-zcode-agent=glm
```

> Note: PR targets `zcode-prompt-format` (the branch this work continues). Happy to retarget to `master` if preferred.
