### PR TITLE
ci: add release pipeline with multi-platform binaries and Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+dist
+.git
+.github
+*.log
+config.yaml
+.DS_Store
+zcode-proxy.exe
+zcode-proxy-linux-*
+zcode-proxy-darwin-*
+docs
+_reverse
+.omo

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+changelog:
+  categories:
+    - title: Features
+      labels:
+        - feat
+        - feature
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - fix
+        - bug
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,12 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "New release tag, e.g. v2.1.0"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -12,15 +15,27 @@ jobs:
   detect:
     runs-on: ubuntu-latest
     outputs:
-      is_prerelease: ${{ steps.check.outputs.is_prerelease }}
+      tag: ${{ steps.check.outputs.tag }}
       version: ${{ steps.check.outputs.version }}
+      is_prerelease: ${{ steps.check.outputs.is_prerelease }}
     steps:
-      - name: Determine version and prerelease
+      - name: Validate tag and determine prerelease
         id: check
+        env:
+          TAG: ${{ inputs.tag }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          TAG="${GITHUB_REF_NAME}"
+          if ! printf '%s' "$TAG" | grep -qE '^v'; then
+            echo "::error::Release tag must start with 'v' (got: '$TAG')"
+            exit 1
+          fi
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" >/dev/null 2>&1; then
+            echo "::error::Tag '$TAG' already exists on the remote"
+            exit 1
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
-          if echo "$TAG" | grep -qiE 'alpha|beta|rc'; then
+          if printf '%s' "$TAG" | grep -qiE 'alpha|beta|rc'; then
             echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
           else
             echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
@@ -83,6 +98,13 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v4
+      - name: Create and push tag
+        env:
+          TAG: ${{ needs.detect.outputs.tag }}
+        run: |
+          git tag "$TAG"
+          git push origin "$TAG"
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
@@ -91,7 +113,8 @@ jobs:
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
-          name: ${{ github.ref_name }}
+          tag_name: ${{ needs.detect.outputs.tag }}
+          name: ${{ needs.detect.outputs.tag }}
           generate_release_notes: true
           prerelease: ${{ needs.detect.outputs.is_prerelease }}
           files: dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,23 @@ jobs:
             echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
           fi
 
-  build-binaries:
+  verify:
     needs: detect
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1"
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Type check
+        run: bun x tsc --noEmit
+      - name: Run tests
+        run: bun test
+
+  build-binaries:
+    needs: [detect, verify]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -82,7 +97,7 @@ jobs:
           files: dist/*
 
   docker:
-    needs: detect
+    needs: [detect, release]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,119 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      is_prerelease: ${{ steps.check.outputs.is_prerelease }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - name: Determine version and prerelease
+        id: check
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+          if echo "$TAG" | grep -qiE 'alpha|beta|rc'; then
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  build-binaries:
+    needs: detect
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: bun-windows-x64
+            outfile: zcode-proxy.exe
+          - target: bun-linux-x64
+            outfile: zcode-proxy-linux-x64
+          - target: bun-linux-arm64
+            outfile: zcode-proxy-linux-arm64
+          - target: bun-darwin-x64
+            outfile: zcode-proxy-darwin-x64
+          - target: bun-darwin-arm64
+            outfile: zcode-proxy-darwin-arm64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1"
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Build binary
+        run: >-
+          bun build --compile --target=${{ matrix.target }}
+          --define "require.resolve=undefined"
+          src/index.ts --outfile ${{ matrix.outfile }}
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.outfile }}
+          path: ${{ matrix.outfile }}
+          if-no-files-found: error
+
+  release:
+    needs: [detect, build-binaries]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          generate_release_notes: true
+          prerelease: ${{ needs.detect.outputs.is_prerelease }}
+          files: dist/*
+
+  docker:
+    needs: detect
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Compute lowercase image name
+        id: img
+        run: echo "name=ghcr.io/${GITHUB_REPOSITORY_OWNER@L}/zcode-proxy" >> "$GITHUB_OUTPUT"
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.img.outputs.name }}
+          flavor: latest=false
+          tags: |
+            type=raw,value=${{ needs.detect.outputs.version }}
+            type=raw,value=latest,enable=${{ needs.detect.outputs.is_prerelease == 'false' }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 /_reverse
 /zcode-proxy.exe
 /zcode-proxy-linux-*
+/zcode-proxy-darwin-*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1
+
+FROM oven/bun:1-alpine AS deps
+WORKDIR /app
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile
+
+FROM oven/bun:1-alpine
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY package.json tsconfig.json config.example.yaml ./
+COPY src ./src
+RUN mkdir -p /data && chown bun:bun /data
+ENV ZCODE_PROXY_PORT=8080
+ENV ZCODE_PROXY_CONFIG=/data/config.yaml
+EXPOSE 8080
+USER bun
+CMD ["bun", "run", "src/index.ts", "serve"]

--- a/README.md
+++ b/README.md
@@ -201,6 +201,58 @@ bun run src/index.ts config.yaml
 bun run build
 ```
 
+## Docker
+
+Pull the multi-arch image from GitHub Packages (ghcr.io):
+
+```bash
+docker pull ghcr.io/tridefender/zcode-proxy:latest
+```
+
+Run with env-var configuration (no config file needed):
+
+```bash
+docker run --rm -p 8080:8080 \
+  -e ZCODE_API_KEY="yourApiKey.yourSecretKey" \
+  -e ZCODE_PROVIDER=zai \
+  -e ZCODE_PROXY_API_KEY="your-proxy-secret" \
+  ghcr.io/tridefender/zcode-proxy:latest
+```
+
+Or mount a config file:
+
+```bash
+docker run --rm -p 8080:8080 \
+  -v "$(pwd)/config.yaml:/data/config.yaml:ro" \
+  ghcr.io/tridefender/zcode-proxy:latest
+```
+
+> Note: `/health` and all routes sit behind the proxy-API-key check, so health probes must send `x-api-key: <ZCODE_PROXY_API_KEY>`.
+
+Common environment variables (see the Configuration table above for the full list):
+
+| Env Var | Description |
+|---------|-------------|
+| `ZCODE_API_KEY` | Upstream API key (`{apiKey}.{secretKey}` for Z.AI, `{apiKey}` for Bigmodel) |
+| `ZCODE_PROVIDER` | `zai` or `bigmodel` |
+| `ZCODE_PROXY_API_KEY` | Client auth shared secret |
+| `ZCODE_PROXY_PORT` | Listen port (default `8080`) |
+
+docker-compose:
+
+```yaml
+services:
+  zcode-proxy:
+    image: ghcr.io/tridefender/zcode-proxy:latest
+    ports:
+      - "8080:8080"
+    environment:
+      ZCODE_API_KEY: "yourApiKey.yourSecretKey"
+      ZCODE_PROVIDER: zai
+      ZCODE_PROXY_API_KEY: "your-proxy-secret"
+    restart: unless-stopped
+```
+
 ## Available Models
 
 The proxy lists these models on `GET /v1/models` (pinned to the GLM coding-plan tier):

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "test": "bun test",
     "build": "bun build --compile --define \"require.resolve=undefined\" src/index.ts --outfile zcode-proxy.exe",
     "build:linux-x64": "bun build --compile --target bun-linux-x64 --define \"require.resolve=undefined\" src/index.ts --outfile zcode-proxy-linux-x64",
-    "build:linux-arm64": "bun build --compile --target bun-linux-arm64 --define \"require.resolve=undefined\" src/index.ts --outfile zcode-proxy-linux-arm64"
+    "build:linux-arm64": "bun build --compile --target bun-linux-arm64 --define \"require.resolve=undefined\" src/index.ts --outfile zcode-proxy-linux-arm64",
+    "build:darwin-x64": "bun build --compile --target bun-darwin-x64 --define \"require.resolve=undefined\" src/index.ts --outfile zcode-proxy-darwin-x64",
+    "build:darwin-arm64": "bun build --compile --target bun-darwin-arm64 --define \"require.resolve=undefined\" src/index.ts --outfile zcode-proxy-darwin-arm64"
   },
   "dependencies": {
     "yaml": "^2.5.0",


### PR DESCRIPTION
利用 CC 按现有 release 模板编写了 release ci。
* push version tag 时自动创建 release，changelog 用 Github 预设的模板
 * 编译 linux、windows、darwin 的二进制
 * 编译 linux amd64、arm64 的容器然后推送到 github packages
 
Ref: 
* https://github.com/greenhat616/zcode-api/releases
* https://github.com/greenhat616/zcode-api/pkgs/container/zcode-proxy