### PR TITLE
Preserve explicit session trace metadata and ordered upstream headers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,119 @@
+# PROJECT KNOWLEDGE BASE
+
+**Generated:** 2026-06-24
+**Commit:** b43eb16
+**Branch:** master
+
+## OVERVIEW
+`zcode-proxy` (v2.0.2) — a Bun + TypeScript reverse proxy that exposes Z.AI / Bigmodel.cn
+coding-plan APIs through both OpenAI-compatible (`/v1/chat/completions`) and Anthropic-format
+(`/v1/messages`) endpoints, translating between the two and injecting the ZCode desktop-client
+fingerprint so requests are accepted upstream.
+
+## STRUCTURE
+```
+zcodeplus/
+├── src/                 # ALL app code (ESM, run directly by Bun — no build step for dev)
+│   ├── index.ts         # CLI entry: serve | auth login/logout/status | version | help
+│   ├── integration.test.ts  # full e2e (mock upstream via in-process Bun.serve)
+│   ├── auth/            # OAuth (device/auth-code), AES-GCM credential store, key resolution
+│   ├── config/          # YAML loader (env>YAML>defaults), types, bundled template
+│   ├── provider/        # Provider registry (zai|bigmodel) + pinned GLM model list
+│   ├── proxy/           # HOT CORE: request pipeline, identity headers, captcha, body mutation
+│   ├── server/          # Bun.serve bootstrap, CORS, proxy-key auth, route handlers
+│   └── translator/      # OpenAI<->Anthropic body + SSE translation (bidirectional)
+├── _reverse/            # [GITIGNORED, READ-ONLY] reverse-engineered ZCode bundle — the spec source
+├── config.example.yaml  # annotated template — EMBEDDED into the compiled binary (template.ts)
+├── config.test.yaml     # test fixture (port 19090, fake keys, mock upstream)
+├── config.yaml          # [GITIGNORED] live config with real secrets
+├── PROMPT.md            # extracted ZCode system-prompt structure (reference, not app logic)
+└── zcode-proxy*         # [GITIGNORED] compiled single-file binaries
+```
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| Add/change a request-transform rule | `src/proxy/body-transformer.ts` | stream_options, cache_control, user_id, start-plan system blocks |
+| Change injected identity headers | `src/proxy/identity.ts` | 5 headers mirror ZCode desktop; do not add/omit |
+| Add an upstream header / auth scheme | `src/proxy/upstream.ts` | `STRIP_HEADERS` set + `anthropic-version` const |
+| Add a CLI command / flag | `src/index.ts` | `main()` dispatches on `args[0]` |
+| Add a model | `src/provider/models.ts` + `config.example.yaml` `models:` | listing is informational, not a gate |
+| Add a provider | `src/provider/providers.ts` + `ProxyConfig.providers` type | only `zai`\|`bigmodel` validated at load |
+| Change config cascade / validation | `src/config/loader.ts` | env var → YAML → default; throws on invalid provider |
+| Add an HTTP route | `src/server/{server,routes-*}.ts` | OpenAI routes vs Anthropic routes split by format |
+| Debug a proxied request | run `zcode-proxy serve debug` | prints URL, redacted headers, body preview, TTFB/tok/s table |
+| Understand upstream protocol | `_reverse/NOTEPAD.md` + `_reverse/zcode.cjs` | READ-ONLY; the canonical reference |
+
+## CODE MAP
+Grounded in codegraph (LSP unavailable). Refs = inbound import count across `src/`.
+
+| Symbol | Type | Location | Refs | Role |
+|--------|------|----------|:----:|------|
+| `proxyRequest` | fn | `src/proxy/handler.ts:52` | 3 | **HOT CORE** — full request pipeline (auth→translate→forward→stream) |
+| `errorResponse` | fn | `src/proxy/handler.ts:235` | 3 | JSON error body builder |
+| `loadConfig` | fn | `src/config/loader.ts` | 4 | YAML+env loader, validation, identity defaults |
+| `startServer` | fn | `src/server/server.ts` | 3 | Bun.serve bootstrap + routing |
+| `AuthManager` | class | `src/auth/manager.ts` | 5 | per-request credential resolution (apikey\|oauth) |
+| `buildUpstreamRequest` | fn | `src/proxy/upstream.ts` | 2 | URL + auth + identity header assembly |
+| `transformRequestBody` | fn | `src/proxy/body-transformer.ts` | 2 | ZCode-equivalent body mutations |
+| `buildIdentityHeaders` | fn | `src/proxy/identity.ts` | 2 | the 5 fingerprint headers |
+| `getProvider` | fn | `src/provider/providers.ts` | 2 | provider def lookup |
+| `ProxyConfig` | type | `src/config/types.ts:48` | 7 | top-level config shape |
+| `Credential` | type | `src/auth/types.ts` | 7 | credential record + `credentialString()` |
+| `ProviderId` | type | `src/provider/types.ts` | 11 | `"zai"`\|`"bigmodel"` — used everywhere |
+| `ProxyIdentity` | type | `src/config/types.ts:41` | 4 | identity header source values |
+| `Format` | type | `src/translator/types.ts` | 5 | `"openai"`\|`"anthropic"` |
+
+Request hot path: `server.ts → routes-{openai,anthropic}.ts → proxyRequest() → auth.getCredential() + transformRequestBody() + buildUpstreamRequest() → fetch → {translate\|passthrough}`.
+
+## CONVENTIONS
+- **Bun-only.** Runtime, package manager, test runner, and compiler are all Bun. No Node, no npm/yarn/pnpm. `bun run src/index.ts` executes TS directly.
+- **ESM with `.js` import specifiers.** `"type": "module"`; every import ends in `.js` even for `.ts` source (e.g. `from "./loader.js"`).
+- **`tsconfig` is type-check only** (`noEmit: true`, `strict`, `moduleResolution: "bundler"`, `types: ["bun-types"]`). Verify types with `bun x tsc --noEmit`.
+- **Tests:** `bun:test`, co-located as `*.test.ts` next to the SUT. Mock fetch via `fetchImpl` injection or `bun:test` `mock()`. 215 tests, all green. Integration tests spin up a real `Bun.serve` mock upstream on a random port.
+- **No linter / formatter / CI.** Match surrounding style by hand (see `PROMPT.md`).
+- **Config cascade:** env var → YAML → hardcoded default. See `config.example.yaml` for the full annotated schema.
+- **File naming:** kebab-case files; PascalCase exported classes/interfaces; no barrel `index.ts` files — import named modules directly.
+
+## ANTI-PATTERNS (THIS PROJECT)
+1. **NEVER call `close()` after `error()` on a ReadableStreamController** — `src/translator/sse-translator.ts`. They're mutually exclusive; `close()` post-error throws `TypeError` that crashes the Bun engine. Guard with an `errored` flag.
+2. **NEVER dynamically `import("jsdom")`** — `src/proxy/captcha.ts:12`. Under `bun build --compile` it yields `{default:{}}` with no named exports. Use static `import { JSDOM, VirtualConsole }`.
+3. **NEVER load the AliyunCaptcha SDK from CDN at runtime** — `src/proxy/captcha.ts:4`. CDN is the #1 solve-failure source; a local path breaks under `--compile`. Bundle as `import ... with { type: "text" }`.
+4. **NEVER swallow AliyunCaptcha errors in `getInstance`** — if `reject()` isn't called in every callback (`getInstance`/`fail`/`onError`), `success` never fires and the solver hangs to the outer timeout.
+5. **NEVER commit `config.yaml`** (real secrets) or modify **`_reverse/`** (read-only reverse-engineered artifacts). Only `config.example.yaml` is tracked.
+6. **Passthrough (Anthropic) mode MUST use `decompress: false`**; translation (OpenAI) mode MUST NOT (it needs to read+translate the body). See `src/proxy/handler.ts:41-50`.
+7. **Do NOT add an upstream timeout** on LLM calls — intentionally matches ZCode desktop; only connection errors surface as 502.
+8. **`appVersion` must be printable ASCII** (`/^[\x20-\x7e]+$/`) — non-conforming values are silently dropped, falling back to `"3.1.1"` (mirrors the bundle's `rYn`). Intentional.
+9. **Start-plan gateway REQUIRES ZCode identity system blocks** — without them `zcode.z.ai` returns 3012. They're auto-prepended by `transformRequestBody` when `startPlan=true`.
+10. **CORS `access-control-allow-origin: *` is intentional** (self-use proxy) — don't restrict it.
+11. **Legacy Z.AI device/poll OAuth flow is dead** (`/oauth/cli/init`+`poll` → 404). Only the auth-code flow works (`src/auth/oauth.ts`).
+
+## UNIQUE STYLES
+- **Single-binary cross-compile:** `bun build --compile` (with `--define "require.resolve=undefined"`) emits self-contained `zcode-proxy.exe` / `-linux-x64` / `-linux-arm64` from one `src/index.ts`.
+- **Identity mimicry as a feature:** the whole point is to impersonate the ZCode desktop client (User-Agent, X-ZCode-*, HTTP-Referer) so upstream accepts the request. See `_reverse/NOTEPAD.md` "How Credential is Used".
+- **`config.example.yaml` is the source of truth** for both the runtime default AND the embedded template (`src/config/template.ts` imports it as text). Changing config schema means editing both.
+- **Two plan tiers** drive most branching: `coding-plan` (direct upstream, API key) vs `start-plan` (zcode.z.ai gateway, JWT + captcha). Almost every module has `if (startPlan)` paths.
+
+## COMMANDS
+```bash
+bun install                       # deps
+bun run dev                       # = bun run src/index.ts (defaults to serve + config.yaml)
+bun run src/index.ts serve debug [config.yaml]   # verbose per-request diagnostics
+bun run src/index.ts auth login bigmodel         # OAuth login (or: zai)
+bun run src/index.ts auth login bigmodel --import # import key from ~/.zcode/v2/config.json
+bun test                          # all tests (215)
+bun x tsc --noEmit                # type-check only
+bun run build                     # → zcode-proxy.exe (Windows)
+bun run build:linux-x64           # cross-compile Linux x64
+bun run build:linux-arm64         # cross-compile Linux arm64
+```
+Key env: `ZCODE_PROXY_PORT` (8080), `ZCODE_API_KEY`, `ZCODE_PROXY_API_KEY`, `ZCODE_PROVIDER` (zai), `ZCODE_PROXY_CONFIG` (config.yaml). Start-plan captcha tunables: `ZCODE_CAPTCHA_RETRIES`, `ZCODE_CAPTCHA_TIMEOUT_MS`, `ZCODE_CAPTCHA_SDK_LOAD_MS`.
+
+## NOTES
+- **Version mismatch:** `package.json` says `2.0.2` but `src/index.ts` hardcodes `VERSION = "2.0.1"`. Keep in sync when bumping.
+- **`_reverse/` is the spec.** `zcode.cjs` (9.4MB, deobfuscated) is the canonical reference for upstream behavior; `NOTEPAD.md` distills auth flows + endpoints; `models_catalog.json` is the authoritative model list. `tsconfig` and `.gitignore` both exclude it.
+- **Test coverage gaps (no dedicated tests):** `src/proxy/captcha.ts`, `src/proxy/system-prompt.ts`, `src/config/template.ts`, `src/server/routes-{openai,anthropic}.ts`. `proxy/handler.ts` has no dedicated test (exercised via `upstream.test.ts`, `handler-debug.test.ts`, `integration.test.ts`).
+- **`config.yaml` auto-creates** from the bundled template on first `serve` if missing.
+- **OAuth credentials** are AES-256-GCM encrypted at `~/.zcode-proxy/credentials.json`.
+- **Subdirectory knowledge bases:** `src/proxy/AGENTS.md`, `src/auth/AGENTS.md`, `src/translator/AGENTS.md` (provider/server/config are covered above).
+```

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -61,5 +61,14 @@ identity:
   # HTTP-Referer URL. Default "https://zcode.z.ai".
   refererOrigin: "https://zcode.z.ai"
 
+# Local client-session inference for cache-affinity experiments.
+# "observe" (default) logs inferred sessions in debug mode but does not change
+# upstream x-session-id. "enforce" reuses a stable x-session-id for inferred
+# coding-plan sessions. "off" disables inference entirely.
+clientIdentity:
+  mode: observe
+  ttlSeconds: 900
+  maxSessions: 1024
+
 logging:
   level: info

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,721 @@
+{
+  "name": "zcode-proxy",
+  "version": "2.0.5.alpha",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "zcode-proxy",
+      "version": "2.0.5.alpha",
+      "dependencies": {
+        "jsdom": "^25.0.0",
+        "yaml": "^2.5.0"
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "@types/jsdom": "^28.0.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/bun": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.3.14.tgz",
+      "integrity": "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bun-types": "1.3.14"
+      }
+    },
+    "node_modules/@types/jsdom": {
+      "version": "28.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^8.0.0",
+        "undici-types": "^7.21.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "license": "MIT"
+    },
+    "node_modules/bun-types": {
+      "version": "1.3.14",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "7.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "license": "ISC"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "license": "MIT"
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "license": "MIT"
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "license": "MIT"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/src/auth/AGENTS.md
+++ b/src/auth/AGENTS.md
@@ -1,0 +1,39 @@
+# src/auth
+
+Credential lifecycle: how the proxy obtains, stores, and resolves the upstream credential.
+Two paths — `apikey` (a key you already have) and `oauth` (browser login → token exchange →
+API-key resolution). Both converge on a `Credential` that `proxy/upstream.ts` turns into auth
+headers per request.
+
+## STRUCTURE
+```
+auth/
+├── manager.ts    # AuthManager: per-request getCredential() (apikey | oauth)
+├── apikey.ts     # createApiKeyCredential(): parse "{apiKey}.{secret}" / "{apiKey}"
+├── oauth.ts      # ZaiOAuthClient / BigmodelOAuthClient: auth-code flow + token exchange
+├── resolver.ts   # KeyResolver: OAuth token → biz token → org/project → coding-plan API key
+├── store.ts      # AES-256-GCM encrypted credential file (~/.zcode-proxy/credentials.json)
+└── types.ts      # Credential, AuthMode, credentialString(), isExpired()
+```
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| Change per-request credential selection | `manager.ts:getCredential` | apikey returns parsed key; oauth loads+decrypts, checks expiry |
+| Fix provider-specific key format | `apikey.ts` + `types.ts:credentialString` | zai = `{apiKey}.{secret}`, bigmodel = `{apiKey}` |
+| Change the OAuth login flow | `oauth.ts` | auth-code flow only; callback binds `127.0.0.1` |
+| Change how an OAuth token becomes an API key | `resolver.ts` | biz token → customerInfo → org/project → find/create key |
+| Change credential storage / key derivation | `store.ts` | AES-256-GCM; key from `ZCODE_CREDENTIAL_SECRET` or host-derived fallback |
+| Add/adjust an expiry rule | `types.ts:isExpired` | drives whether oauth re-resolution kicks in |
+
+## CONVENTIONS
+- **Credential format is provider-specific and split-on-first-dot.** Z.AI needs `{apiKey}.{secret}` (the proxy sends the whole string as `x-api-key`); Bigmodel sends `{apiKey}` only. `credentialString()` assembles it; never JSON-split or trim it.
+- **OAuth is auth-code, not device/poll.** The legacy `/oauth/cli/init` + `/oauth/cli/poll` endpoints 404. Both providers share one token-exchange endpoint at `zcode.z.ai`; only the authorize URL + query-param scheme differ (`oauth.ts` `AuthCodeConfig`).
+- **Key resolution is a 3-call chain** (`resolver.ts`): `getCustomerInfo` (pick org "默认机构" + project "默认项目") → list/create `api_keys` (name `zcode-api-key`) → `api_keys/copy/{id}` for the `secretKey`. Z.AI stitches `{apiKey}.{secret}`; Bigmodel keeps just `apiKey`.
+- **OAuth credentials carry an optional `jwt`** for start-plan (the `zcode.z.ai` gateway token) alongside the provider `apiKey`. Don't drop it on save/load.
+- **The callback server is localhost-only** (`oauth.ts:138`, `127.0.0.1`). Security requirement — don't widen it.
+
+## ANTI-PATTERNS
+- **Don't split a Z.AI key on every dot** — split on the FIRST dot only (`{apiKey}.{secret}`); a secret may itself contain dots.
+- **Don't skip `isExpired()`** before handing out an oauth credential — a stale token surfaces as upstream 401, not a clean proxy error.
+- **Don't print the full credential string.** It's the upstream secret. `index.ts` only ever logs `apiKey.substring(0,12)...`.

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -75,6 +75,32 @@ auth:
     expect(cfg.logging.level).toBe("info");
     expect(cfg.providers.zai.anthropicBase).toBe("https://api.z.ai/api/anthropic");
     expect(cfg.providers.bigmodel.openaiBase).toBe("https://open.bigmodel.cn/api/coding/paas/v4");
+    expect(cfg.clientIdentity).toEqual({ mode: "observe", ttlSeconds: 900, maxSessions: 1024 });
+  });
+
+  it("clientIdentity: YAML values override defaults", () => {
+    const path = writeYaml(`
+auth:
+  mode: apikey
+  apiKey: "abc"
+clientIdentity:
+  mode: enforce
+  ttlSeconds: 60
+  maxSessions: 8
+`);
+    const cfg = loadConfig(path);
+    expect(cfg.clientIdentity).toEqual({ mode: "enforce", ttlSeconds: 60, maxSessions: 8 });
+  });
+
+  it("throws on invalid clientIdentity.mode", () => {
+    const path = writeYaml(`
+auth:
+  mode: apikey
+  apiKey: "abc"
+clientIdentity:
+  mode: always
+`);
+    expect(() => loadConfig(path)).toThrow(/Invalid clientIdentity\.mode/);
   });
 
   it("env vars override YAML values", () => {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -4,7 +4,7 @@
  */
 import { readFileSync, existsSync } from "node:fs";
 import { parse } from "yaml";
-import type { ProxyConfig, ProviderEndpoints, ProxyIdentity } from "./types.js";
+import type { ClientIdentityConfig, ProxyConfig, ProviderEndpoints, ProxyIdentity } from "./types.js";
 
 /** Environment variable keys that override YAML values. */
 const ENV = {
@@ -31,6 +31,9 @@ const DEFAULTS = {
   APP_VERSION: "3.1.5",
   SOURCE_TITLE: "cli",
   REFERER_ORIGIN: "https://zcode.z.ai",
+  CLIENT_IDENTITY_MODE: "observe" as const,
+  CLIENT_IDENTITY_TTL_SECONDS: 900,
+  CLIENT_IDENTITY_MAX_SESSIONS: 1024,
 };
 
 /** Printable-ASCII gate copied from the ZCode bundle's `rYn` helper. */
@@ -91,6 +94,8 @@ export function loadConfig(path: string): ProxyConfig {
     refererYaml: parsed?.identity?.refererOrigin,
   });
 
+  const clientIdentity = resolveClientIdentity(parsed?.clientIdentity);
+
   const config: ProxyConfig = {
     server: { port, host },
     auth: { proxyApiKey, mode, apiKey, oauthCredentialsPath },
@@ -100,11 +105,35 @@ export function loadConfig(path: string): ProxyConfig {
     defaultModel,
     models,
     identity,
+    clientIdentity,
     logging: { level: logLevel },
   };
 
   validate(config);
   return config;
+}
+
+function resolveClientIdentity(raw: unknown): ClientIdentityConfig {
+  const obj = raw && typeof raw === "object" ? raw as Record<string, unknown> : {};
+  const mode = resolveClientIdentityMode(obj.mode);
+  const ttlSeconds = resolvePositiveInt(obj.ttlSeconds, DEFAULTS.CLIENT_IDENTITY_TTL_SECONDS, "clientIdentity.ttlSeconds");
+  const maxSessions = resolvePositiveInt(obj.maxSessions, DEFAULTS.CLIENT_IDENTITY_MAX_SESSIONS, "clientIdentity.maxSessions");
+  return { mode, ttlSeconds, maxSessions };
+}
+
+function resolveClientIdentityMode(raw: unknown): ClientIdentityConfig["mode"] {
+  if (raw === undefined || raw === null) return DEFAULTS.CLIENT_IDENTITY_MODE;
+  if (raw === "off" || raw === "observe" || raw === "enforce") return raw;
+  throw new Error(`Invalid clientIdentity.mode "${String(raw)}": must be "off", "observe", or "enforce"`);
+}
+
+function resolvePositiveInt(raw: unknown, fallback: number, name: string): number {
+  if (raw === undefined || raw === null) return fallback;
+  const n = typeof raw === "number" ? raw : parseInt(String(raw), 10);
+  if (!Number.isInteger(n) || n < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return n;
 }
 
 /** Resolve port from raw value (YAML or env), defaulting to 8080. */

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -44,6 +44,16 @@ export interface ProxyIdentity {
   refererOrigin: string;
 }
 
+/** Local client-session inference mode for upstream session affinity. */
+export interface ClientIdentityConfig {
+  /** "observe" logs/instruments only; "enforce" reuses upstream x-session-id; "off" disables inference. */
+  mode: "off" | "observe" | "enforce";
+  /** In-memory session TTL in seconds. */
+  ttlSeconds: number;
+  /** Maximum number of inferred sessions retained in memory. */
+  maxSessions: number;
+}
+
 /** Top-level proxy configuration. */
 export interface ProxyConfig {
   server: {
@@ -69,6 +79,8 @@ export interface ProxyConfig {
    * defaults mirror the production ZCode desktop client.
    */
   identity: ProxyIdentity;
+  /** Local client session inference for cache-affinity experiments. */
+  clientIdentity: ClientIdentityConfig;
   logging: {
     level: "debug" | "info" | "warn" | "error";
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,6 +145,7 @@ function printDebugBanner(config: ProxyConfig, path: string): void {
   console.log(`  provider: ${config.provider}`);
   console.log(`  plan: ${config.plan}`);
   console.log(`  identity: appVersion=${config.identity.appVersion} sourceTitle=${config.identity.sourceTitle} referer=${config.identity.refererOrigin}`);
+  console.log(`  client identity: mode=${config.clientIdentity.mode} ttl=${config.clientIdentity.ttlSeconds}s max=${config.clientIdentity.maxSessions}`);
   console.log(`  anthropic base: ${active.anthropicBase}`);
   console.log(`  openai base:    ${active.openaiBase}`);
   console.log(`  credential: ${credShape}`);

--- a/src/proxy/AGENTS.md
+++ b/src/proxy/AGENTS.md
@@ -1,0 +1,57 @@
+# src/proxy
+
+The hot core: the full request pipeline between the server routes and the upstream.
+Everything auth-injection, identity-spoofing, body-mutation, captcha, and response
+streaming/translation lives here. See root `AGENTS.md` for the project-level anti-patterns
+(jsdom import, captcha CDN, `decompress` rules, no upstream timeout) — they all originate here.
+
+## STRUCTURE
+```
+proxy/
+├── handler.ts          # proxyRequest(): the pipeline. Largest file (~520 LOC).
+├── upstream.ts         # buildUpstreamRequest(): URL + auth + identity header assembly
+├── body-transformer.ts # transformRequestBody(): ZCode-equivalent body mutations
+├── identity.ts         # buildIdentityHeaders(): the 5 fingerprint headers
+├── captcha.ts          # Aliyun CAPTCHA V3 solver (start-plan only, jsdom-based)
+├── system-prompt.ts    # buildStartPlanSystem(): gateway identity blocks (loads zcode_system.json)
+├── zcode_system.json   # static ZCode system-prompt payload, prepended on start-plan
+└── AliyunCaptcha.js.txt# vendored SDK source, loaded as text (NOT from CDN)
+```
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| Change request flow / add a branch | `handler.ts:proxyRequest` | reads body → auth → translate → transform → build → fetch → {stream\|batch} |
+| Change which headers go upstream | `upstream.ts` | `STRIP_HEADERS` set + per-plan auth header pick |
+| Add a body mutation | `body-transformer.ts` | keyed by `{format, startPlan}`; see existing 4 mutations |
+| Change the desktop fingerprint | `identity.ts` | exactly 5 headers — adding one likely breaks upstream acceptance |
+| Fix captcha solve failures | `captcha.ts` | singleton solver; `getCaptchaToken`/`invalidateCaptchaToken`/`detectCaptchaChallenge` |
+| Tune the request log table | `handler.ts:printRow/printHeader/observeStream` | the `#NNN \| Time \| Fmt \| Model \| Stat \| TTFB \| Tok \| tok/s \| Total` table |
+
+## PIPELINE DETAIL (proxyRequest)
+```
+readBody → peekBody(model,stream) → auth.getCredential()
+  [openai] translateOpenAIBody → anthropic body
+  transformRequestBody(upstreamFormat, userId, startPlan)
+  [start-plan] getCaptchaToken → captcha headers
+  buildUpstreamRequest(...)
+  fetch(upstream, translateMode ? {} : { decompress:false })
+    [start-plan 401] → 401 start_plan_jwt_invalid (re-login needed)
+    [start-plan 403/captcha] → invalidate + re-solve + retry ONCE
+  [translate+SSE] anthropicSseToOpenaiSse (tee'd: one stream to client, one to observeStream stats)
+  [translate+batch] translatedBatchResponse (re-gzip if client accepts)
+  [passthrough] passthroughResponse (preserve content-encoding, forward ratelimit headers)
+```
+`reqId` is a module-global counter (`#001`, `#002`…); `printHeader` prints the table once.
+
+## CONVENTIONS
+- **Two response modes share one fetch:** passthrough streams raw bytes (`decompress:false`), translation lets Bun inflate so the body can be rewritten. Never mix the option across the two branches.
+- **Captcha is lazy + cached:** `getCaptchaToken` solves once and caches; a 403 challenge invalidates and re-solves exactly once (`handler.ts:143-166`). Don't make it eager — solving costs a browser-less DOM round-trip.
+- **Identity blocks are prepended, not merged:** `body-transformer` prepends `buildStartPlanSystem()` for start-plan; the gateway content-inspects them or returns 3012. Keep them first.
+- **Forwarded response headers are an explicit allowlist** (`handler.ts:209-220`, `:316-326`): `content-type`, `content-encoding`, `cache-control`, `x-request-id`, and the `anthropic-ratelimit-*` family. Add new upstream headers here, not ad hoc.
+- **`reqId` / debug lines are stdlib-only:** `proxyRequest` is pure aside from the module-global request counter and `console.log`. Tests inject `fetchImpl` and capture `console.log` — keep it that way.
+
+## ANTI-PATTERNS
+- **Don't retry the same failing captcha token verbatim** — invalidate then re-solve (`handler.ts:147`). A 403 means the token was rejected upstream.
+- **Don't read `upstreamResp.body` twice** — translation mode either `.text()`s it (batch) or hands the stream to `anthropicSseToOpenaiSse`; passthrough tees it. A second read is empty.
+- **Don't add an upstream `AbortController`/timeout** — see root anti-pattern #7. Connection errors only.

--- a/src/proxy/client-session.test.ts
+++ b/src/proxy/client-session.test.ts
@@ -15,6 +15,102 @@ function makeReq(body: string, headers: Record<string, string> = {}): Request {
 const CFG = { mode: "enforce" as const, ttlSeconds: 900, maxSessions: 1024 };
 
 describe("client session resolver", () => {
+  it("preserves explicit ZCode-style metadata IDs without hashing them", () => {
+    const resolver = createClientSessionResolver();
+    const body = JSON.stringify({
+      model: "glm-4.6",
+      metadata: {
+        requestId: "req_client_1",
+        traceId: "trace_client_1",
+        queryId: "query_turn_1",
+        sessionId: "sess_thread_1",
+      },
+      messages: [{ role: "user", content: "Hi" }],
+    });
+
+    const result = resolver.resolve(makeReq(body), body, "anthropic", "glm-4.6", CFG);
+
+    expect(result.source).toBe("explicit");
+    expect(result.requestId).toBe("req_client_1");
+    expect(result.traceId).toBe("trace_client_1");
+    expect(result.queryId).toBe("query_turn_1");
+    expect(result.sessionId).toBe("sess_thread_1");
+    expect(result.upstreamSessionId).toBe("sess_thread_1");
+  });
+
+  it("preserves explicit subagent session headers for emission-time prefix stripping", () => {
+    const resolver = createClientSessionResolver();
+    const body = JSON.stringify({ model: "glm-4.6", messages: [{ role: "user", content: "Hi" }] });
+    const result = resolver.resolve(makeReq(body, {
+      "x-request-id": "req_header_1",
+      "x-zcode-trace-id": "trace_header_1",
+      "x-query-id": "query_header_1",
+      "x-session-id": "subagent_agent_worker_1",
+    }), body, "anthropic", "glm-4.6", CFG);
+
+    expect(result.source).toBe("explicit");
+    expect(result.requestId).toBe("req_header_1");
+    expect(result.traceId).toBe("trace_header_1");
+    expect(result.queryId).toBe("query_header_1");
+    expect(result.sessionId).toBe("subagent_agent_worker_1");
+    expect(result.upstreamSessionId).toBe("subagent_agent_worker_1");
+  });
+
+  it("keeps existing snake_case metadata session fallbacks", () => {
+    const resolver = createClientSessionResolver();
+    const body = JSON.stringify({
+      model: "glm-4.6",
+      metadata: {
+        request_id: "req_legacy_1",
+        trace_id: "trace_legacy_1",
+        query_id: "query_legacy_1",
+        session_id: "sess_legacy_1",
+      },
+      messages: [{ role: "user", content: "Hi" }],
+    });
+
+    const result = resolver.resolve(makeReq(body), body, "anthropic", "glm-4.6", CFG);
+
+    expect(result.requestId).toBe("req_legacy_1");
+    expect(result.traceId).toBe("trace_legacy_1");
+    expect(result.queryId).toBe("query_legacy_1");
+    expect(result.sessionId).toBe("sess_legacy_1");
+  });
+  it("keeps lineage session inference when metadata only provides trace IDs", () => {
+    const resolver = createClientSessionResolver();
+    const body1 = JSON.stringify({
+      model: "glm-4.6",
+      metadata: {
+        requestId: "req_turn_1",
+        traceId: "trace_turn_1",
+        queryId: "query_turn_1",
+      },
+      messages: [{ role: "user", content: "Hi" }],
+    });
+    const body2 = JSON.stringify({
+      model: "glm-4.6",
+      metadata: {
+        requestId: "req_turn_2",
+        traceId: "trace_turn_2",
+        queryId: "query_turn_2",
+      },
+      messages: [{ role: "user", content: "Hi" }],
+    });
+
+    const first = resolver.resolve(makeReq(body1), body1, "anthropic", "glm-4.6", CFG);
+    const second = resolver.resolve(makeReq(body2), body2, "anthropic", "glm-4.6", CFG);
+
+    expect(first.source).toBe("lineage");
+    expect(first.upstreamSessionId).toBeTruthy();
+    expect(first.requestId).toBe("req_turn_1");
+    expect(first.traceId).toBe("trace_turn_1");
+    expect(first.queryId).toBe("query_turn_1");
+    expect(second.source).toBe("lineage");
+    expect(second.upstreamSessionId).toBe(first.upstreamSessionId);
+    expect(second.requestId).toBe("req_turn_2");
+    expect(second.traceId).toBe("trace_turn_2");
+    expect(second.queryId).toBe("query_turn_2");
+  });
   it("reuses the same session for exact request bodies", () => {
     const resolver = createClientSessionResolver();
     const body = JSON.stringify({ model: "glm-4.6", messages: [{ role: "user", content: "Hi" }] });

--- a/src/proxy/client-session.test.ts
+++ b/src/proxy/client-session.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for local client session inference.
+ */
+import { describe, it, expect } from "bun:test";
+import { createClientSessionResolver } from "./client-session.js";
+
+function makeReq(body: string, headers: Record<string, string> = {}): Request {
+  return new Request("http://localhost:8080/v1/messages", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body,
+  });
+}
+
+const CFG = { mode: "enforce" as const, ttlSeconds: 900, maxSessions: 1024 };
+
+describe("client session resolver", () => {
+  it("reuses the same session for exact request bodies", () => {
+    const resolver = createClientSessionResolver();
+    const body = JSON.stringify({ model: "glm-4.6", messages: [{ role: "user", content: "Hi" }] });
+
+    const first = resolver.resolve(makeReq(body), body, "anthropic", "glm-4.6", CFG);
+    const second = resolver.resolve(makeReq(body), body, "anthropic", "glm-4.6", CFG);
+
+    expect(first.source).toBe("lineage");
+    expect(second.sessionId).toBe(first.sessionId);
+    expect(second.upstreamSessionId).toBe(first.upstreamSessionId);
+    expect(second.confidence).toBeGreaterThanOrEqual(0.9);
+  });
+
+  it("reuses the same session for a linear continuation", () => {
+    const resolver = createClientSessionResolver();
+    const firstBody = JSON.stringify({ model: "glm-4.6", messages: [{ role: "user", content: "Hi" }] });
+    const nextBody = JSON.stringify({
+      model: "glm-4.6",
+      messages: [
+        { role: "user", content: "Hi" },
+        { role: "assistant", content: "Hello" },
+        { role: "user", content: "Next" },
+      ],
+    });
+
+    const first = resolver.resolve(makeReq(firstBody), firstBody, "anthropic", "glm-4.6", CFG);
+    const next = resolver.resolve(makeReq(nextBody), nextBody, "anthropic", "glm-4.6", CFG);
+
+    expect(next.sessionId).toBe(first.sessionId);
+    expect(next.source).toBe("lineage");
+  });
+
+  it("creates separate sessions for forked continuations from the same parent", () => {
+    const resolver = createClientSessionResolver();
+    const parentBody = JSON.stringify({ model: "glm-4.6", messages: [{ role: "user", content: "Hi" }] });
+    const forkA = JSON.stringify({
+      model: "glm-4.6",
+      messages: [{ role: "user", content: "Hi" }, { role: "user", content: "A" }],
+    });
+    const forkB = JSON.stringify({
+      model: "glm-4.6",
+      messages: [{ role: "user", content: "Hi" }, { role: "user", content: "B" }],
+    });
+
+    resolver.resolve(makeReq(parentBody), parentBody, "anthropic", "glm-4.6", CFG);
+    const a = resolver.resolve(makeReq(forkA), forkA, "anthropic", "glm-4.6", CFG);
+    const b = resolver.resolve(makeReq(forkB), forkB, "anthropic", "glm-4.6", CFG);
+
+    expect(a.sessionId).not.toBe(b.sessionId);
+    expect(a.upstreamSessionId).not.toBe(b.upstreamSessionId);
+  });
+
+  it("canonicalizes OpenAI requests while ignoring transport and sampling fields", () => {
+    const resolver = createClientSessionResolver();
+    const firstBody = JSON.stringify({
+      model: "glm-4.6",
+      stream: true,
+      temperature: 0.2,
+      messages: [{ role: "system", content: "sys" }, { role: "user", content: "Hi" }],
+    });
+    const secondBody = JSON.stringify({
+      model: "glm-4.6",
+      stream: false,
+      temperature: 0.9,
+      messages: [{ role: "system", content: "sys" }, { role: "user", content: "Hi" }],
+    });
+
+    const first = resolver.resolve(makeReq(firstBody), firstBody, "openai", "glm-4.6", CFG);
+    const second = resolver.resolve(makeReq(secondBody), secondBody, "openai", "glm-4.6", CFG);
+
+    expect(second.sessionId).toBe(first.sessionId);
+  });
+
+  it("does not throw or allocate a session for malformed or empty bodies", () => {
+    const resolver = createClientSessionResolver();
+
+    const malformed = resolver.resolve(makeReq("not-json"), "not-json", "anthropic", "glm-4.6", CFG);
+    const empty = resolver.resolve(makeReq(""), undefined, "anthropic", "glm-4.6", CFG);
+
+    expect(malformed.source).toBe("none");
+    expect(malformed.sessionId).toBeUndefined();
+    expect(empty.source).toBe("none");
+    expect(empty.sessionId).toBeUndefined();
+  });
+});

--- a/src/proxy/client-session.ts
+++ b/src/proxy/client-session.ts
@@ -16,6 +16,9 @@ export interface ClientSessionResult {
   confidence: number;
   sessionId?: string;
   upstreamSessionId?: string;
+  requestId?: string;
+  traceId?: string;
+  queryId?: string;
 }
 
 interface StoredNode {
@@ -29,6 +32,13 @@ interface CanonicalRequest {
   model: string;
   identity: unknown;
   messages: unknown[];
+}
+
+interface ExplicitTraceContext {
+  requestId?: string;
+  traceId?: string;
+  queryId?: string;
+  sessionId?: string;
 }
 
 export interface ClientSessionResolver {
@@ -80,28 +90,31 @@ export function createClientSessionResolver(now: () => number = () => Date.now()
       if (config.mode === "off") return { source: "none", action: "off", confidence: 0 };
 
       prune(config);
-      const explicit = resolveExplicit(req, body, config);
-      if (explicit) return { ...explicit, action: action(config) };
+      const explicitTrace = requestTraceContext(req, body);
+      if (explicitTrace.sessionId) return explicitResult(explicitTrace, config);
 
       const canonical = canonicalize(body, format, model);
-      if (!canonical) return { source: "none", action: action(config), confidence: 0 };
+      if (!canonical) {
+        if (hasTraceContext(explicitTrace)) return explicitResult(explicitTrace, config);
+        return { source: "none", action: action(config), confidence: 0 };
+      }
 
       const nodeHash = hashJson(canonical.identity);
       const existing = nodes.get(nodeHash);
       if (existing) {
         remember(nodeHash, existing, config);
-        return result("lineage", action(config), existing, 0.95);
+        return withTraceContext(result("lineage", action(config), existing, 0.95), explicitTrace);
       }
 
       const parent = findLinearParent(canonical, nodes);
       if (parent) {
         remember(nodeHash, parent, config);
-        return result("lineage", action(config), parent, 0.9);
+        return withTraceContext(result("lineage", action(config), parent, 0.9), explicitTrace);
       }
 
       const fresh = newSession();
       remember(nodeHash, fresh, config);
-      return result("lineage", action(config), fresh, 0.75);
+      return withTraceContext(result("lineage", action(config), fresh, 0.75), explicitTrace);
     },
   };
 }
@@ -118,19 +131,41 @@ function result(source: ClientSessionSource, action: ClientSessionAction, node: 
   };
 }
 
-function resolveExplicit(req: Request, body: string | undefined, config: ClientIdentityConfig): ClientSessionResult | null {
-  const headerValue = firstHeader(req.headers, ["x-opencode-session", "x-session-id", "x-parent-session-id", "helicone-session-id"]);
-  const bodyValue = bodyMetadataSession(body);
-  const raw = headerValue ?? bodyValue;
-  if (!raw) return null;
-  const sessionId = `ses_${hashString(raw).slice(0, 12)}`;
+function requestTraceContext(req: Request, body: string | undefined): ExplicitTraceContext {
+  const bodyTrace = bodyMetadataTrace(body);
+  return {
+    requestId: firstHeader(req.headers, ["x-request-id"]) ?? bodyTrace.requestId,
+    traceId: firstHeader(req.headers, ["x-zcode-trace-id"]) ?? bodyTrace.traceId,
+    queryId: firstHeader(req.headers, ["x-query-id"]) ?? bodyTrace.queryId,
+    sessionId: firstHeader(req.headers, ["x-opencode-session", "x-session-id", "x-parent-session-id", "helicone-session-id"])
+      ?? bodyTrace.sessionId,
+  };
+}
+
+function explicitResult(trace: ExplicitTraceContext, config: ClientIdentityConfig): ClientSessionResult {
   return {
     source: "explicit",
     action: config.mode,
     confidence: 1,
-    sessionId,
-    upstreamSessionId: uuidFromHash(raw),
+    ...(trace.requestId ? { requestId: trace.requestId } : {}),
+    ...(trace.traceId ? { traceId: trace.traceId } : {}),
+    ...(trace.queryId ? { queryId: trace.queryId } : {}),
+    ...(trace.sessionId ? { sessionId: trace.sessionId, upstreamSessionId: trace.sessionId } : {}),
   };
+}
+
+function withTraceContext(session: ClientSessionResult, trace: ExplicitTraceContext): ClientSessionResult {
+  if (!trace.requestId && !trace.traceId && !trace.queryId) return session;
+  return {
+    ...session,
+    ...(trace.requestId ? { requestId: trace.requestId } : {}),
+    ...(trace.traceId ? { traceId: trace.traceId } : {}),
+    ...(trace.queryId ? { queryId: trace.queryId } : {}),
+  };
+}
+
+function hasTraceContext(trace: ExplicitTraceContext): boolean {
+  return Boolean(trace.requestId || trace.traceId || trace.queryId || trace.sessionId);
 }
 
 function firstHeader(headers: Headers, names: string[]): string | null {
@@ -141,16 +176,29 @@ function firstHeader(headers: Headers, names: string[]): string | null {
   return null;
 }
 
-function bodyMetadataSession(body: string | undefined): string | null {
-  if (!body) return null;
+function bodyMetadataTrace(body: string | undefined): ExplicitTraceContext {
+  if (!body) return {};
   try {
     const parsed = JSON.parse(body) as any;
     const metadata = parsed?.metadata;
-    const raw = metadata?.session_id ?? metadata?.conversation_id;
-    return typeof raw === "string" && raw.trim() ? raw.trim() : null;
+    if (!metadata || typeof metadata !== "object") return {};
+    return {
+      requestId: stringProperty(metadata, ["requestId", "request_id"]),
+      traceId: stringProperty(metadata, ["traceId", "trace_id"]),
+      queryId: stringProperty(metadata, ["queryId", "query_id"]),
+      sessionId: stringProperty(metadata, ["sessionId", "session_id", "conversationId", "conversation_id"]),
+    };
   } catch {
-    return null;
+    return {};
   }
+}
+
+function stringProperty(obj: Record<string, unknown>, names: string[]): string | undefined {
+  for (const name of names) {
+    const value = obj[name];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return undefined;
 }
 
 function canonicalize(body: string | undefined, format: Format, fallbackModel: string): CanonicalRequest | null {
@@ -207,14 +255,6 @@ function hashString(value: string): string {
   const bytes = new TextEncoder().encode(value);
   const digest = new Bun.CryptoHasher("sha256").update(bytes).digest("hex");
   return String(digest);
-}
-
-function uuidFromHash(value: string): string {
-  const hex = hashString(value).slice(0, 32).split("");
-  hex[12] = "4";
-  hex[16] = ((parseInt(hex[16] ?? "8", 16) & 0x3) | 0x8).toString(16);
-  const s = hex.join("");
-  return `${s.slice(0, 8)}-${s.slice(8, 12)}-${s.slice(12, 16)}-${s.slice(16, 20)}-${s.slice(20, 32)}`;
 }
 
 function stableStringify(value: unknown): string {

--- a/src/proxy/client-session.ts
+++ b/src/proxy/client-session.ts
@@ -1,0 +1,225 @@
+/**
+ * Local client-session inference for cache-affinity experiments.
+ *
+ * The resolver stores only hashes and generated IDs. It deliberately avoids
+ * prompt markers, response mutation, and full prompt persistence.
+ */
+import type { Format } from "../translator/types.js";
+import type { ClientIdentityConfig } from "../config/types.js";
+
+export type ClientSessionSource = "none" | "explicit" | "lineage";
+export type ClientSessionAction = "off" | "observe" | "enforce";
+
+export interface ClientSessionResult {
+  source: ClientSessionSource;
+  action: ClientSessionAction;
+  confidence: number;
+  sessionId?: string;
+  upstreamSessionId?: string;
+}
+
+interface StoredNode {
+  nodeHash: string;
+  sessionId: string;
+  upstreamSessionId: string;
+  lastSeenAt: number;
+}
+
+interface CanonicalRequest {
+  model: string;
+  identity: unknown;
+  messages: unknown[];
+}
+
+export interface ClientSessionResolver {
+  resolve(req: Request, body: string | undefined, format: Format, model: string, config: ClientIdentityConfig): ClientSessionResult;
+}
+
+export function createClientSessionResolver(now: () => number = () => Date.now()): ClientSessionResolver {
+  const nodes = new Map<string, StoredNode>();
+  const sessions = new Map<string, StoredNode>();
+
+  function remember(nodeHash: string, session: StoredNode, config: ClientIdentityConfig): void {
+    const stored = { ...session, nodeHash, lastSeenAt: now() };
+    nodes.set(nodeHash, stored);
+    sessions.set(stored.sessionId, stored);
+    prune(config);
+  }
+
+  function prune(config: ClientIdentityConfig): void {
+    const cutoff = now() - config.ttlSeconds * 1000;
+    for (const [hash, node] of nodes.entries()) {
+      if (node.lastSeenAt < cutoff) nodes.delete(hash);
+    }
+    for (const [id, node] of sessions.entries()) {
+      if (node.lastSeenAt < cutoff) sessions.delete(id);
+    }
+    while (sessions.size > config.maxSessions) {
+      let oldestId = "";
+      let oldestAt = Infinity;
+      for (const [id, node] of sessions.entries()) {
+        if (node.lastSeenAt < oldestAt) {
+          oldestAt = node.lastSeenAt;
+          oldestId = id;
+        }
+      }
+      if (!oldestId) break;
+      sessions.delete(oldestId);
+      for (const [hash, node] of nodes.entries()) {
+        if (node.sessionId === oldestId) nodes.delete(hash);
+      }
+    }
+  }
+
+  function action(config: ClientIdentityConfig): ClientSessionAction {
+    return config.mode;
+  }
+
+  return {
+    resolve(req, body, format, model, config) {
+      if (config.mode === "off") return { source: "none", action: "off", confidence: 0 };
+
+      prune(config);
+      const explicit = resolveExplicit(req, body, config);
+      if (explicit) return { ...explicit, action: action(config) };
+
+      const canonical = canonicalize(body, format, model);
+      if (!canonical) return { source: "none", action: action(config), confidence: 0 };
+
+      const nodeHash = hashJson(canonical.identity);
+      const existing = nodes.get(nodeHash);
+      if (existing) {
+        remember(nodeHash, existing, config);
+        return result("lineage", action(config), existing, 0.95);
+      }
+
+      const parent = findLinearParent(canonical, nodes);
+      if (parent) {
+        remember(nodeHash, parent, config);
+        return result("lineage", action(config), parent, 0.9);
+      }
+
+      const fresh = newSession();
+      remember(nodeHash, fresh, config);
+      return result("lineage", action(config), fresh, 0.75);
+    },
+  };
+}
+
+export const defaultClientSessionResolver = createClientSessionResolver();
+
+function result(source: ClientSessionSource, action: ClientSessionAction, node: StoredNode, confidence: number): ClientSessionResult {
+  return {
+    source,
+    action,
+    confidence,
+    sessionId: node.sessionId,
+    upstreamSessionId: node.upstreamSessionId,
+  };
+}
+
+function resolveExplicit(req: Request, body: string | undefined, config: ClientIdentityConfig): ClientSessionResult | null {
+  const headerValue = firstHeader(req.headers, ["x-opencode-session", "x-session-id", "x-parent-session-id", "helicone-session-id"]);
+  const bodyValue = bodyMetadataSession(body);
+  const raw = headerValue ?? bodyValue;
+  if (!raw) return null;
+  const sessionId = `ses_${hashString(raw).slice(0, 12)}`;
+  return {
+    source: "explicit",
+    action: config.mode,
+    confidence: 1,
+    sessionId,
+    upstreamSessionId: uuidFromHash(raw),
+  };
+}
+
+function firstHeader(headers: Headers, names: string[]): string | null {
+  for (const name of names) {
+    const value = headers.get(name);
+    if (value && value.trim()) return value.trim();
+  }
+  return null;
+}
+
+function bodyMetadataSession(body: string | undefined): string | null {
+  if (!body) return null;
+  try {
+    const parsed = JSON.parse(body) as any;
+    const metadata = parsed?.metadata;
+    const raw = metadata?.session_id ?? metadata?.conversation_id;
+    return typeof raw === "string" && raw.trim() ? raw.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+function canonicalize(body: string | undefined, format: Format, fallbackModel: string): CanonicalRequest | null {
+  if (!body) return null;
+  let parsed: any;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+
+  const model = typeof parsed.model === "string" ? parsed.model : fallbackModel;
+  const messages = Array.isArray(parsed.messages) ? parsed.messages : [];
+  if (messages.length === 0) return null;
+
+  const identity = {
+    format,
+    model,
+    system: parsed.system,
+    developer: messages.filter((m: any) => m?.role === "developer"),
+    tools: parsed.tools,
+    tool_choice: parsed.tool_choice,
+    messages,
+  };
+  return { model, identity, messages };
+}
+
+function findLinearParent(canonical: CanonicalRequest, nodes: Map<string, StoredNode>): StoredNode | null {
+  if (canonical.messages.length < 3) return null;
+  const prefix = {
+    ...(canonical.identity as Record<string, unknown>),
+    messages: canonical.messages.slice(0, -2),
+  };
+  if ((prefix.messages as unknown[]).length === 0) return null;
+  return nodes.get(hashJson(prefix)) ?? null;
+}
+
+function newSession(): StoredNode {
+  const upstreamSessionId = crypto.randomUUID();
+  return {
+    nodeHash: "",
+    sessionId: `ses_${upstreamSessionId.replace(/-/g, "").slice(0, 12)}`,
+    upstreamSessionId,
+    lastSeenAt: Date.now(),
+  };
+}
+
+function hashJson(value: unknown): string {
+  return hashString(stableStringify(value));
+}
+
+function hashString(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  const digest = new Bun.CryptoHasher("sha256").update(bytes).digest("hex");
+  return String(digest);
+}
+
+function uuidFromHash(value: string): string {
+  const hex = hashString(value).slice(0, 32).split("");
+  hex[12] = "4";
+  hex[16] = ((parseInt(hex[16] ?? "8", 16) & 0x3) | 0x8).toString(16);
+  const s = hex.join("");
+  return `${s.slice(0, 8)}-${s.slice(8, 12)}-${s.slice(12, 16)}-${s.slice(16, 20)}-${s.slice(20, 32)}`;
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  const obj = value as Record<string, unknown>;
+  return `{${Object.keys(obj).sort().map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(",")}}`;
+}

--- a/src/proxy/handler-debug.test.ts
+++ b/src/proxy/handler-debug.test.ts
@@ -26,6 +26,7 @@ const TEST_CONFIG: ProxyConfig = {
   defaultModel: "glm-4.6",
   models: ["glm-4.6"],
   identity: IDENTITY,
+  clientIdentity: { mode: "observe", ttlSeconds: 900, maxSessions: 1024 },
   logging: { level: "info" },
 };
 
@@ -163,5 +164,67 @@ describe("proxyRequest debug mode", () => {
     });
 
     expect(lines.some((l) => l.includes("debug: translated OpenAI→Anthropic"))).toBe(true);
+  });
+
+  it("emits observe-only client identity inference without stabilizing x-session-id", async () => {
+    const auth = new AuthManager({ mode: "apikey", provider: "zai", apiKey: "testkey.testsecret" });
+    const body = '{"model":"glm-4.6","messages":[{"role":"user","content":"Hi"}]}';
+    const seenSessions: string[] = [];
+
+    const lines = await captureConsoleLog(async () => {
+      for (let i = 0; i < 2; i++) {
+        const resp = await proxyRequest(makeClientReq(body), "anthropic", {
+          config: TEST_CONFIG,
+          auth,
+          debug: true,
+          fetchImpl: mockFetch(async (req) => {
+            seenSessions.push(req.headers.get("x-session-id") ?? "");
+            return anthropicOk();
+          }),
+        });
+        expect(resp.status).toBe(200);
+      }
+    });
+
+    expect(lines.some((l) => l.includes("clientIdentity source=lineage action=observe"))).toBe(true);
+    expect(seenSessions[0]).toBeTruthy();
+    expect(seenSessions[1]).toBeTruthy();
+    expect(seenSessions[0]).not.toBe(seenSessions[1]);
+  });
+
+  it("stabilizes x-session-id in enforce mode for the same inferred session", async () => {
+    const auth = new AuthManager({ mode: "apikey", provider: "zai", apiKey: "testkey.testsecret" });
+    const body = '{"model":"glm-4.6","messages":[{"role":"user","content":"Hi"}]}';
+    const seenSessions: string[] = [];
+    const config: ProxyConfig = { ...TEST_CONFIG, clientIdentity: { mode: "enforce", ttlSeconds: 900, maxSessions: 1024 } };
+
+    for (let i = 0; i < 2; i++) {
+      const resp = await proxyRequest(makeClientReq(body), "anthropic", {
+        config,
+        auth,
+        fetchImpl: mockFetch(async (req) => {
+          seenSessions.push(req.headers.get("x-session-id") ?? "");
+          return anthropicOk();
+        }),
+      });
+      expect(resp.status).toBe(200);
+    }
+
+    expect(seenSessions[0]).toBeTruthy();
+    expect(seenSessions[1]).toBe(seenSessions[0]);
+  });
+
+  it("emits client identity debug line even when no session can be inferred", async () => {
+    const auth = new AuthManager({ mode: "apikey", provider: "zai", apiKey: "testkey.testsecret" });
+    const lines = await captureConsoleLog(async () => {
+      await proxyRequest(makeClientReq('{"model":"glm-4.6","messages":[]}'), "anthropic", {
+        config: TEST_CONFIG,
+        auth,
+        debug: true,
+        fetchImpl: mockFetch(async () => anthropicOk()),
+      });
+    });
+
+    expect(lines.some((l) => l.includes("clientIdentity source=none action=observe confidence=0.00 session=-"))).toBe(true);
   });
 });

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -145,9 +145,10 @@ export async function proxyRequest(
     return errorResponse(401, "start_plan_jwt_invalid", "Start-plan JWT was rejected. Re-run: zcode-proxy auth login");
   }
 
-  // start-plan: on 403 captcha challenge, force re-solve and retry once
-  if (startPlan && (upstreamResp.status === 403 || detectCaptchaChallenge(upstreamResp))) {
-    if (debug) debugLine(reqId, "403/captcha challenge — re-solving and retrying once");
+  // start-plan: on explicit captcha challenge, force re-solve and retry once
+  const captchaChallenge = startPlan ? detectCaptchaChallenge(upstreamResp) : null;
+  if (captchaChallenge) {
+    if (debug) debugLine(reqId, "captcha challenge — re-solving and retrying once");
     try { upstreamResp.body?.cancel(); } catch {}
     console.log(`${reqId} captcha challenge, re-solving...`);
     invalidateCaptchaToken();

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -13,9 +13,11 @@ import type { Format } from "../translator/types.js";
 import type { ProxyConfig } from "../config/types.js";
 import type { AuthManager } from "../auth/manager.js";
 import { getProvider } from "../provider/providers.js";
-import { buildUpstreamRequest } from "./upstream.js";
+import { buildUpstreamHeaderPairs, buildUpstreamRequest, type UpstreamHeaderPair } from "./upstream.js";
+import { sendOrderedUpstreamRequest } from "./ordered-transport.js";
 import { transformRequestBody } from "./body-transformer.js";
-import { defaultClientSessionResolver, type ClientSessionResult } from "./client-session.js";
+import { type ClientSessionResult } from "./client-session.js";
+import { resolveSessionContext } from "./session-context.js";
 import { detectCaptchaChallenge, getCaptchaToken, invalidateCaptchaToken, RETRY_HEADERS } from "./captcha.js";
 import { translateRequestOpenAIToAnthropic, translateResponseAnthropicToOpenAI } from "../translator/openai-to-anthropic.js";
 import { translateRequestAnthropicToOpenAI, translateResponseOpenAIToAnthropic } from "../translator/anthropic-to-openai.js";
@@ -58,6 +60,7 @@ export async function proxyRequest(
 ): Promise<Response> {
   const { config, auth } = opts;
   const fetchImpl = opts.fetchImpl ?? fetch;
+  const hasCustomFetchImpl = opts.fetchImpl !== undefined;
   const debug = opts.debug === true;
   const started = Date.now();
   const reqId = nextReqId();
@@ -86,7 +89,11 @@ export async function proxyRequest(
   const translateAnthropicToOpenAI = startPlan && format === "anthropic";
   const translateOpenAIToAnthropic = !startPlan && format === "openai";
   const upstreamFormat: Format = startPlan ? "openai" : (translateOpenAIToAnthropic ? "anthropic" : format);
-  const clientSession = resolveClientSession(clientReq, body, upstreamFormat, meta.model, config, debug, reqId);
+  const clientSession = resolveSessionContext({ clientReq, body, upstreamFormat, model: meta.model, config });
+  if (debug && clientSession) {
+    const shortSession = clientSession.sessionId ? clientSession.sessionId.slice(0, 10) : "-";
+    debugLine(reqId, `clientIdentity source=${clientSession.source} action=${clientSession.action} confidence=${clientSession.confidence.toFixed(2)} session=${shortSession}`);
+  }
 
   let upstreamBody = body;
   if (translateOpenAIToAnthropic) {
@@ -116,6 +123,8 @@ export async function proxyRequest(
     }
   }
 
+  const useOrderedTransport = shouldUseOrderedTransport(config, clientSession, hasCustomFetchImpl);
+  let upstreamHeaderPairs = buildUpstreamHeaderPairs(clientReq, upstreamFormat, cred, config.identity, config.plan, captchaHeaders, clientSession);
   let upstreamReq = buildUpstreamRequest(clientReq, upstreamFormat, provider, cred, transformedBody, config.identity, config.plan, captchaHeaders, clientSession);
 
   if (debug) {
@@ -126,7 +135,7 @@ export async function proxyRequest(
 
   let upstreamResp: Response;
   try {
-    upstreamResp = await fetchImpl(upstreamReq, translateOpenAIToAnthropic || translateAnthropicToOpenAI ? {} : { decompress: false });
+    upstreamResp = await sendUpstreamRequest(upstreamReq, upstreamHeaderPairs, transformedBody, translateOpenAIToAnthropic || translateAnthropicToOpenAI, useOrderedTransport, fetchImpl);
   } catch (err) {
     if (debug) debugError(reqId, "upstream_unreachable", (err as Error).message);
     printRow(reqId, format, meta, 502, started, Date.now(), 0, 0, 0);
@@ -155,11 +164,13 @@ export async function proxyRequest(
     try {
       const fresh = await getCaptchaToken(config.identity.appVersion);
       console.log(`${reqId} captcha re-solved (token ${fresh.verifyParam.length} chars), retrying...`);
-      upstreamReq = buildUpstreamRequest(clientReq, upstreamFormat, provider, cred, transformedBody, config.identity, config.plan, {
+      const retryHeaders = {
         [RETRY_HEADERS.PARAM]: fresh.verifyParam,
         [RETRY_HEADERS.REGION]: fresh.region,
-      }, clientSession);
-      upstreamResp = await fetchImpl(upstreamReq, translateOpenAIToAnthropic || translateAnthropicToOpenAI ? {} : { decompress: false }).catch((err: Error) => {
+      };
+      upstreamHeaderPairs = buildUpstreamHeaderPairs(clientReq, upstreamFormat, cred, config.identity, config.plan, retryHeaders, clientSession);
+      upstreamReq = buildUpstreamRequest(clientReq, upstreamFormat, provider, cred, transformedBody, config.identity, config.plan, retryHeaders, clientSession);
+      upstreamResp = await sendUpstreamRequest(upstreamReq, upstreamHeaderPairs, transformedBody, translateOpenAIToAnthropic || translateAnthropicToOpenAI, useOrderedTransport, fetchImpl).catch((err: Error) => {
         if (debug) debugError(reqId, "upstream_unreachable", err.message);
         printRow(reqId, format, meta, 502, started, Date.now(), 0, 0, 0);
         return errorResponse(502, "upstream_unreachable", err.message);
@@ -214,22 +225,29 @@ export async function proxyRequest(
   return passthroughResponse(upstreamResp);
 }
 
-function resolveClientSession(
-  clientReq: Request,
+export function shouldUseOrderedTransport(config: ProxyConfig, clientSession: ClientSessionResult | undefined, hasCustomFetchImpl: boolean): boolean {
+  if (hasCustomFetchImpl) return false;
+  return clientSession?.action === "enforce" || clientSession?.source === "explicit";
+}
+
+async function sendUpstreamRequest(
+  upstreamReq: Request,
+  headerPairs: UpstreamHeaderPair[],
   body: string | undefined,
-  upstreamFormat: Format,
-  model: string,
-  config: ProxyConfig,
-  debug: boolean,
-  reqId: string,
-): ClientSessionResult | undefined {
-  if (config.plan === "start-plan" || config.clientIdentity.mode === "off") return undefined;
-  const session = defaultClientSessionResolver.resolve(clientReq, body, upstreamFormat, model, config.clientIdentity);
-  if (debug) {
-    const shortSession = session.sessionId ? session.sessionId.slice(0, 10) : "-";
-    debugLine(reqId, `clientIdentity source=${session.source} action=${session.action} confidence=${session.confidence.toFixed(2)} session=${shortSession}`);
+  translateMode: boolean,
+  useOrderedTransport: boolean,
+  fetchImpl: typeof fetch,
+): Promise<Response> {
+  if (useOrderedTransport) {
+    return sendOrderedUpstreamRequest({
+      url: upstreamReq.url,
+      method: upstreamReq.method,
+      headers: headerPairs,
+      body,
+      decompress: translateMode,
+    });
   }
-  return session;
+  return fetchImpl(upstreamReq, translateMode ? {} : { decompress: false });
 }
 
 /** Read the request body as a string, returning undefined for empty bodies. */

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -15,6 +15,7 @@ import type { AuthManager } from "../auth/manager.js";
 import { getProvider } from "../provider/providers.js";
 import { buildUpstreamRequest } from "./upstream.js";
 import { transformRequestBody } from "./body-transformer.js";
+import { defaultClientSessionResolver, type ClientSessionResult } from "./client-session.js";
 import { detectCaptchaChallenge, getCaptchaToken, invalidateCaptchaToken, RETRY_HEADERS } from "./captcha.js";
 import { translateRequestOpenAIToAnthropic, translateResponseAnthropicToOpenAI } from "../translator/openai-to-anthropic.js";
 import { translateRequestAnthropicToOpenAI, translateResponseOpenAIToAnthropic } from "../translator/anthropic-to-openai.js";
@@ -85,6 +86,7 @@ export async function proxyRequest(
   const translateAnthropicToOpenAI = startPlan && format === "anthropic";
   const translateOpenAIToAnthropic = !startPlan && format === "openai";
   const upstreamFormat: Format = startPlan ? "openai" : (translateOpenAIToAnthropic ? "anthropic" : format);
+  const clientSession = resolveClientSession(clientReq, body, upstreamFormat, meta.model, config, debug, reqId);
 
   let upstreamBody = body;
   if (translateOpenAIToAnthropic) {
@@ -114,7 +116,7 @@ export async function proxyRequest(
     }
   }
 
-  let upstreamReq = buildUpstreamRequest(clientReq, upstreamFormat, provider, cred, transformedBody, config.identity, config.plan, captchaHeaders);
+  let upstreamReq = buildUpstreamRequest(clientReq, upstreamFormat, provider, cred, transformedBody, config.identity, config.plan, captchaHeaders, clientSession);
 
   if (debug) {
     debugLine(reqId, `→ POST ${upstreamReq.url}`);
@@ -155,7 +157,7 @@ export async function proxyRequest(
       upstreamReq = buildUpstreamRequest(clientReq, upstreamFormat, provider, cred, transformedBody, config.identity, config.plan, {
         [RETRY_HEADERS.PARAM]: fresh.verifyParam,
         [RETRY_HEADERS.REGION]: fresh.region,
-      });
+      }, clientSession);
       upstreamResp = await fetchImpl(upstreamReq, translateOpenAIToAnthropic || translateAnthropicToOpenAI ? {} : { decompress: false }).catch((err: Error) => {
         if (debug) debugError(reqId, "upstream_unreachable", err.message);
         printRow(reqId, format, meta, 502, started, Date.now(), 0, 0, 0);
@@ -209,6 +211,24 @@ export async function proxyRequest(
 
   printRow(reqId, format, meta, upstreamResp.status, started, headersAt, 0, 0, 0);
   return passthroughResponse(upstreamResp);
+}
+
+function resolveClientSession(
+  clientReq: Request,
+  body: string | undefined,
+  upstreamFormat: Format,
+  model: string,
+  config: ProxyConfig,
+  debug: boolean,
+  reqId: string,
+): ClientSessionResult | undefined {
+  if (config.plan === "start-plan" || config.clientIdentity.mode === "off") return undefined;
+  const session = defaultClientSessionResolver.resolve(clientReq, body, upstreamFormat, model, config.clientIdentity);
+  if (debug) {
+    const shortSession = session.sessionId ? session.sessionId.slice(0, 10) : "-";
+    debugLine(reqId, `clientIdentity source=${session.source} action=${session.action} confidence=${session.confidence.toFixed(2)} session=${shortSession}`);
+  }
+  return session;
 }
 
 /** Read the request body as a string, returning undefined for empty bodies. */

--- a/src/proxy/ordered-transport.ts
+++ b/src/proxy/ordered-transport.ts
@@ -1,0 +1,248 @@
+import { connect as connectTcp, type Socket } from "node:net";
+import { connect as connectTls, type TLSSocket } from "node:tls";
+
+export type OrderedHeaderPair = [string, string];
+
+export interface OrderedUpstreamRequest {
+  url: string;
+  method?: string;
+  headers: OrderedHeaderPair[];
+  body?: string | Uint8Array;
+  decompress?: boolean;
+}
+
+type WireSocket = Socket | TLSSocket;
+
+const CRLF = "\r\n";
+const HEADER_END = new Uint8Array([13, 10, 13, 10]);
+const HEADER_NAME = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+
+export async function sendOrderedUpstreamRequest(req: OrderedUpstreamRequest): Promise<Response> {
+  const url = new URL(req.url);
+  const bodyBytes = bodyToBytes(req.body);
+  const requestHead = buildRequestHead(url, req.method ?? "POST", req.headers, bodyBytes.byteLength);
+  const socket = await openSocket(url);
+
+  return await new Promise<Response>((resolve, reject) => {
+    let headerBuffer: Uint8Array<ArrayBufferLike> = new Uint8Array(0);
+    let responseStarted = false;
+    let bodyController: ReadableStreamDefaultController<Uint8Array> | null = null;
+    let chunkedDecoder: ChunkedDecoder | null = null;
+    let remainingContentLength: number | null = null;
+
+    const bodyStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        bodyController = controller;
+      },
+      cancel() {
+        socket.destroy();
+      },
+    });
+
+    function fail(err: unknown): void {
+      if (responseStarted) bodyController?.error(err);
+      else reject(err);
+      socket.destroy();
+    }
+
+    function finish(): void {
+      if (chunkedDecoder && !chunkedDecoder.done) return;
+      try { bodyController?.close(); } catch {}
+    }
+
+    function pushBody(bytes: Uint8Array): void {
+      if (!bodyController || bytes.byteLength === 0) return;
+      if (chunkedDecoder) {
+        chunkedDecoder.push(bytes, bodyController);
+        if (chunkedDecoder.done) finish();
+        return;
+      }
+      if (remainingContentLength !== null) {
+        const next = bytes.slice(0, remainingContentLength);
+        remainingContentLength -= next.byteLength;
+        if (next.byteLength > 0) bodyController.enqueue(next);
+        if (remainingContentLength === 0) finish();
+        return;
+      }
+      bodyController.enqueue(bytes);
+    }
+
+    socket.on("data", (chunk: Buffer) => {
+      try {
+        const bytes = new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength);
+        if (!responseStarted) {
+          headerBuffer = concatBytes(headerBuffer, bytes);
+          const headerEnd = indexOfBytes(headerBuffer, HEADER_END);
+          if (headerEnd < 0) return;
+
+          const headerBytes = headerBuffer.slice(0, headerEnd);
+          const rest = headerBuffer.slice(headerEnd + HEADER_END.byteLength);
+          const parsed = parseResponseHeaders(headerBytes);
+          responseStarted = true;
+
+          const transferEncoding = parsed.headers.get("transfer-encoding")?.toLowerCase() ?? "";
+          if (transferEncoding.split(",").map((s) => s.trim()).includes("chunked")) {
+            parsed.headers.delete("transfer-encoding");
+            chunkedDecoder = new ChunkedDecoder();
+          } else {
+            const contentLength = parsed.headers.get("content-length");
+            remainingContentLength = contentLength ? Number.parseInt(contentLength, 10) : null;
+            if (!Number.isFinite(remainingContentLength as number)) remainingContentLength = null;
+          }
+
+          let responseBody: ReadableStream<Uint8Array> = bodyStream;
+          if (req.decompress && parsed.headers.get("content-encoding")?.toLowerCase() === "gzip") {
+            parsed.headers.delete("content-encoding");
+            parsed.headers.delete("content-length");
+            const gzip = new DecompressionStream("gzip") as unknown as ReadableWritablePair<Uint8Array, Uint8Array>;
+            responseBody = bodyStream.pipeThrough(gzip);
+          }
+
+          resolve(new Response(responseBody, {
+            status: parsed.status,
+            statusText: parsed.statusText,
+            headers: parsed.headers,
+          }));
+          pushBody(rest);
+          return;
+        }
+        pushBody(bytes);
+      } catch (err) {
+        fail(err);
+      }
+    });
+
+    socket.once("error", fail);
+    socket.once("end", () => {
+      if (!responseStarted) {
+        reject(new Error("upstream closed before sending response headers"));
+        return;
+      }
+      finish();
+    });
+
+    socket.write(requestHead);
+    if (bodyBytes.byteLength > 0) socket.write(bodyBytes);
+  });
+}
+
+function openSocket(url: URL): Promise<WireSocket> {
+  const isHttps = url.protocol === "https:";
+  if (!isHttps && url.protocol !== "http:") {
+    return Promise.reject(new Error(`Unsupported upstream protocol: ${url.protocol}`));
+  }
+  const port = Number(url.port || (isHttps ? 443 : 80));
+
+  return new Promise((resolve, reject) => {
+    const onConnect = () => {
+      socket.off("error", reject);
+      resolve(socket);
+    };
+    const socket: WireSocket = isHttps
+      ? connectTls({ host: url.hostname, port, servername: url.hostname }, onConnect)
+      : connectTcp({ host: url.hostname, port }, onConnect);
+    socket.once("error", reject);
+  });
+}
+
+function buildRequestHead(url: URL, method: string, headers: OrderedHeaderPair[], contentLength: number): string {
+  const path = `${url.pathname || "/"}${url.search}`;
+  const lines = [
+    `${method} ${path} HTTP/1.1`,
+    `Host: ${url.host}`,
+    ...headers.map(headerLine),
+    `Content-Length: ${contentLength}`,
+    "Connection: close",
+    "",
+    "",
+  ];
+  return lines.join(CRLF);
+}
+
+function headerLine([name, value]: OrderedHeaderPair): string {
+  if (!HEADER_NAME.test(name)) throw new Error(`Invalid upstream header name: ${name}`);
+  if (/[\r\n]/.test(value)) throw new Error(`Invalid upstream header value for ${name}`);
+  return `${name}: ${value}`;
+}
+
+function bodyToBytes(body: string | Uint8Array | undefined): Uint8Array {
+  if (body === undefined) return new Uint8Array(0);
+  if (typeof body === "string") return new TextEncoder().encode(body);
+  return body;
+}
+
+function parseResponseHeaders(bytes: Uint8Array): { status: number; statusText: string; headers: Headers } {
+  const text = new TextDecoder("latin1").decode(bytes);
+  const lines = text.split(CRLF);
+  const statusLine = lines.shift() ?? "";
+  const match = /^HTTP\/\d(?:\.\d)?\s+(\d{3})(?:\s+(.*))?$/.exec(statusLine);
+  if (!match) throw new Error(`Invalid upstream status line: ${statusLine}`);
+
+  const headers = new Headers();
+  for (const line of lines) {
+    if (!line) continue;
+    const idx = line.indexOf(":");
+    if (idx <= 0) continue;
+    headers.append(line.slice(0, idx), line.slice(idx + 1).trimStart());
+  }
+
+  return { status: Number(match[1]), statusText: match[2] ?? "", headers };
+}
+
+class ChunkedDecoder {
+  private buffer: Uint8Array<ArrayBufferLike> = new Uint8Array(0);
+  private expectedSize: number | null = null;
+  done = false;
+
+  push(bytes: Uint8Array, controller: ReadableStreamDefaultController<Uint8Array>): void {
+    if (this.done) return;
+    this.buffer = concatBytes(this.buffer, bytes);
+
+    while (!this.done) {
+      if (this.expectedSize === null) {
+        const lineEnd = indexOfCrlf(this.buffer);
+        if (lineEnd < 0) return;
+        const line = new TextDecoder("latin1").decode(this.buffer.slice(0, lineEnd));
+        const sizeHex = line.split(";", 1)[0].trim();
+        const size = Number.parseInt(sizeHex, 16);
+        if (!Number.isFinite(size)) throw new Error(`Invalid chunk size: ${line}`);
+        this.buffer = this.buffer.slice(lineEnd + 2);
+        this.expectedSize = size;
+        if (size === 0) {
+          this.done = true;
+          return;
+        }
+      }
+
+      if (this.buffer.byteLength < this.expectedSize + 2) return;
+      const chunk = this.buffer.slice(0, this.expectedSize);
+      controller.enqueue(chunk);
+      this.buffer = this.buffer.slice(this.expectedSize + 2);
+      this.expectedSize = null;
+    }
+  }
+}
+
+function concatBytes(a: Uint8Array, b: Uint8Array): Uint8Array {
+  const out = new Uint8Array(a.byteLength + b.byteLength);
+  if (a.byteLength > 0) out.set(a, 0);
+  if (b.byteLength > 0) out.set(b, a.byteLength);
+  return out;
+}
+
+function indexOfBytes(haystack: Uint8Array, needle: Uint8Array): number {
+  outer: for (let i = 0; i <= haystack.byteLength - needle.byteLength; i++) {
+    for (let j = 0; j < needle.byteLength; j++) {
+      if (haystack[i + j] !== needle[j]) continue outer;
+    }
+    return i;
+  }
+  return -1;
+}
+
+function indexOfCrlf(bytes: Uint8Array): number {
+  for (let i = 0; i < bytes.byteLength - 1; i++) {
+    if (bytes[i] === 13 && bytes[i + 1] === 10) return i;
+  }
+  return -1;
+}

--- a/src/proxy/session-context.test.ts
+++ b/src/proxy/session-context.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for unified session context policy.
+ */
+import { describe, expect, it } from "bun:test";
+import type { ProxyConfig } from "../config/types.js";
+import { createClientSessionResolver } from "./client-session.js";
+import { resolveSessionContext, sessionIdForHeader, shouldForwardSessionId } from "./session-context.js";
+
+const BASE_CONFIG: ProxyConfig = {
+  server: { port: 8080, host: "0.0.0.0" },
+  auth: { mode: "apikey", apiKey: "dummy" },
+  provider: "zai",
+  plan: "start-plan",
+  providers: {
+    zai: { anthropicBase: "https://api.z.ai/api/anthropic", openaiBase: "https://api.z.ai/api/coding/paas/v4" },
+    bigmodel: { anthropicBase: "https://open.bigmodel.cn/api/anthropic", openaiBase: "https://open.bigmodel.cn/api/coding/paas/v4" },
+  },
+  defaultModel: "glm-4.6",
+  models: ["glm-4.6"],
+  identity: {
+    appVersion: "3.1.1",
+    sourceTitle: "zcode",
+    refererOrigin: "https://zcode.z.ai",
+  },
+  clientIdentity: { mode: "observe", ttlSeconds: 900, maxSessions: 1024 },
+  logging: { level: "info" },
+};
+
+describe("session context", () => {
+  it("uses the same lineage resolver regardless of plan-specific caller", () => {
+    const resolver = createClientSessionResolver();
+    const body = JSON.stringify({ model: "glm-4.6", messages: [{ role: "user", content: "Hi" }] });
+    const req = new Request("http://localhost:8080/v1/chat/completions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+    });
+
+    const session = resolveSessionContext({
+      clientReq: req,
+      body,
+      upstreamFormat: "openai",
+      model: "glm-4.6",
+      config: BASE_CONFIG,
+      resolver,
+    });
+
+    expect(session?.source).toBe("lineage");
+    expect(session?.action).toBe("observe");
+    expect(session?.upstreamSessionId).toBeTruthy();
+  });
+
+  it("does not resolve any session when clientIdentity mode is off", () => {
+    const body = JSON.stringify({ model: "glm-4.6", messages: [{ role: "user", content: "Hi" }] });
+    const session = resolveSessionContext({
+      clientReq: new Request("http://localhost:8080/v1/chat/completions", { method: "POST", body }),
+      body,
+      upstreamFormat: "openai",
+      model: "glm-4.6",
+      config: { ...BASE_CONFIG, clientIdentity: { ...BASE_CONFIG.clientIdentity, mode: "off" } },
+    });
+
+    expect(session).toBeUndefined();
+  });
+
+  it("forwards session IDs only for explicit or enforce contexts", () => {
+    expect(shouldForwardSessionId({
+      source: "lineage",
+      action: "observe",
+      upstreamSessionId: "11111111-1111-4111-8111-111111111111",
+    })).toBe(false);
+    expect(sessionIdForHeader({
+      source: "lineage",
+      action: "observe",
+      upstreamSessionId: "11111111-1111-4111-8111-111111111111",
+    })).toBeUndefined();
+    expect(sessionIdForHeader({
+      source: "lineage",
+      action: "enforce",
+      upstreamSessionId: "11111111-1111-4111-8111-111111111111",
+    })).toBe("11111111-1111-4111-8111-111111111111");
+    expect(sessionIdForHeader({
+      source: "explicit",
+      action: "observe",
+      upstreamSessionId: "sess_thread_1",
+    })).toBe("sess_thread_1");
+  });
+});

--- a/src/proxy/session-context.ts
+++ b/src/proxy/session-context.ts
@@ -1,0 +1,60 @@
+/**
+ * Session context resolution and header-emission policy.
+ *
+ * Both coding-plan and start-plan call the same resolver. The config decides
+ * whether inferred lineage is only observed or is forwarded upstream.
+ */
+import type { ProxyConfig } from "../config/types.js";
+import type { Format } from "../translator/types.js";
+import {
+  defaultClientSessionResolver,
+  type ClientSessionAction,
+  type ClientSessionResolver,
+  type ClientSessionResult,
+  type ClientSessionSource,
+} from "./client-session.js";
+
+export interface ResolveSessionContextInput {
+  clientReq: Request;
+  body: string | undefined;
+  upstreamFormat: Format;
+  model: string;
+  config: ProxyConfig;
+  resolver?: ClientSessionResolver;
+}
+
+export interface SessionHeaderContext {
+  source?: ClientSessionSource;
+  action: ClientSessionAction;
+  sessionId?: string;
+  upstreamSessionId?: string;
+  requestId?: string;
+  traceId?: string;
+  queryId?: string;
+}
+
+export function resolveSessionContext(input: ResolveSessionContextInput): ClientSessionResult | undefined {
+  if (input.config.clientIdentity.mode === "off") return undefined;
+  const resolver = input.resolver ?? defaultClientSessionResolver;
+  return resolver.resolve(input.clientReq, input.body, input.upstreamFormat, input.model, input.config.clientIdentity);
+}
+
+export function shouldUseExactTraceHeaders(
+  plan: "coding-plan" | "start-plan",
+  session?: SessionHeaderContext,
+): boolean {
+  return plan === "start-plan" || hasExplicitTraceHeaders(session) || shouldForwardSessionId(session);
+}
+
+export function shouldForwardSessionId(session?: SessionHeaderContext): boolean {
+  return session?.source === "explicit" || session?.action === "enforce";
+}
+
+export function sessionIdForHeader(session?: SessionHeaderContext): string | undefined {
+  if (!session || !shouldForwardSessionId(session)) return undefined;
+  return session.upstreamSessionId ?? session.sessionId;
+}
+
+function hasExplicitTraceHeaders(session?: SessionHeaderContext): boolean {
+  return Boolean(session?.requestId || session?.traceId || session?.queryId);
+}

--- a/src/proxy/trace-headers.ts
+++ b/src/proxy/trace-headers.ts
@@ -1,0 +1,29 @@
+export interface ZcodeTraceContext {
+  requestId?: string;
+  traceId?: string;
+  queryId?: string;
+  sessionId?: string;
+}
+
+const QUERY_PREFIX = "query_";
+const SESSION_PREFIXES = ["sess_", "subagent_agent_"];
+
+/** Mirrors ZCode's Bdt/Ioo/Coo/vCr attribution header helper. */
+export function buildZcodeTraceHeaders(ctx: ZcodeTraceContext = {}): Record<string, string> {
+  const queryId = ctx.queryId ? stripHeaderInternalPrefixes(ctx.queryId, [QUERY_PREFIX]) : undefined;
+  const sessionId = ctx.sessionId ? stripHeaderInternalPrefixes(ctx.sessionId, SESSION_PREFIXES) : undefined;
+  return {
+    "x-request-id": ctx.requestId ?? crypto.randomUUID(),
+    "x-zcode-trace-id": ctx.traceId ?? crypto.randomUUID(),
+    ...(queryId ? { "x-query-id": queryId } : {}),
+    ...(sessionId ? { "x-session-id": sessionId } : {}),
+  };
+}
+
+export function stripHeaderInternalPrefixes(value: string, prefixes: string[]): string {
+  let out = value;
+  for (const prefix of prefixes) {
+    if (out.startsWith(prefix) && out.length > prefix.length) out = out.slice(prefix.length);
+  }
+  return out || value;
+}

--- a/src/proxy/upstream.test.ts
+++ b/src/proxy/upstream.test.ts
@@ -110,6 +110,28 @@ describe("buildAuthHeaders", () => {
     expect(h1["x-query-id"]).not.toBe(h2["x-query-id"]);
   });
 
+  it("uses a stable x-session-id when an enforced client session is provided", () => {
+    const session = { action: "enforce" as const, upstreamSessionId: "11111111-1111-4111-8111-111111111111" };
+    const h1 = buildAuthHeaders("openai", ZAI_CRED, IDENTITY, "coding-plan", session);
+    const h2 = buildAuthHeaders("openai", ZAI_CRED, IDENTITY, "coding-plan", session);
+
+    expect(h1["x-session-id"]).toBe("11111111-1111-4111-8111-111111111111");
+    expect(h2["x-session-id"]).toBe("11111111-1111-4111-8111-111111111111");
+    expect(h1["x-request-id"]).not.toBe(h2["x-request-id"]);
+    expect(h1["x-zcode-trace-id"]).not.toBe(h2["x-zcode-trace-id"]);
+    expect(h1["x-query-id"]).not.toBe(h2["x-query-id"]);
+  });
+
+  it("does not stabilize x-session-id for observe-only client sessions", () => {
+    const session = { action: "observe" as const, upstreamSessionId: "11111111-1111-4111-8111-111111111111" };
+    const h1 = buildAuthHeaders("openai", ZAI_CRED, IDENTITY, "coding-plan", session);
+    const h2 = buildAuthHeaders("openai", ZAI_CRED, IDENTITY, "coding-plan", session);
+
+    expect(h1["x-session-id"]).toBeTruthy();
+    expect(h2["x-session-id"]).toBeTruthy();
+    expect(h1["x-session-id"]).not.toBe(h2["x-session-id"]);
+  });
+
   it("does not synthesize start-plan query/session headers when no trace context exists", () => {
     const h = buildAuthHeaders("anthropic", { ...ZAI_CRED, jwt: "jwt-token" }, IDENTITY, "start-plan");
 
@@ -181,6 +203,7 @@ describe("proxyRequest", () => {
     defaultModel: "glm-4.6",
     models: ["glm-4.6"],
     identity: IDENTITY,
+    clientIdentity: { mode: "observe", ttlSeconds: 900, maxSessions: 1024 },
     logging: { level: "info" },
   };
 
@@ -318,6 +341,7 @@ describe("proxyRequest — OpenAI translation mode (coding-plan)", () => {
     defaultModel: "glm-4.6",
     models: ["glm-4.6"],
     identity: IDENTITY,
+    clientIdentity: { mode: "observe", ttlSeconds: 900, maxSessions: 1024 },
     logging: { level: "info" },
   };
 
@@ -547,6 +571,7 @@ describe("proxyRequest — regression: Anthropic passthrough unchanged", () => {
     defaultModel: "glm-4.6",
     models: ["glm-4.6"],
     identity: IDENTITY,
+    clientIdentity: { mode: "observe", ttlSeconds: 900, maxSessions: 1024 },
     logging: { level: "info" },
   };
 
@@ -688,6 +713,7 @@ describe("proxyRequest — tool-call roundtrip (OpenAI client through Anthropic 
     defaultModel: "glm-4.6",
     models: ["glm-4.6"],
     identity: IDENTITY,
+    clientIdentity: { mode: "observe", ttlSeconds: 900, maxSessions: 1024 },
     logging: { level: "info" },
   };
 

--- a/src/proxy/upstream.test.ts
+++ b/src/proxy/upstream.test.ts
@@ -3,8 +3,11 @@
  * @see .omo/plans/zcode-proxy.md Task 6
  */
 import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { createServer } from "node:net";
 import { buildUpstreamRequest, buildUpstreamURL, buildAuthHeaders } from "./upstream.js";
-import { proxyRequest, errorResponse } from "./handler.js";
+import { sendOrderedUpstreamRequest } from "./ordered-transport.js";
+import { buildZcodeTraceHeaders } from "./trace-headers.js";
+import { proxyRequest, errorResponse, shouldUseOrderedTransport } from "./handler.js";
 import { ZAI_PROVIDER, BIGMODEL_PROVIDER } from "../provider/providers.js";
 import type { Credential } from "../auth/types.js";
 import type { ProxyConfig, ProxyIdentity } from "../config/types.js";
@@ -25,6 +28,36 @@ function makeClientReq(body: string, headers: Record<string, string> = {}): Requ
     headers: { "content-type": "application/json", ...headers },
     body,
   });
+}
+
+async function captureOrderedRequest(headers: Array<[string, string]>): Promise<{ raw: string; response: Response }> {
+  let resolveRaw!: (raw: string) => void;
+  const rawPromise = new Promise<string>((resolve) => { resolveRaw = resolve; });
+  const server = createServer((socket) => {
+    let raw = "";
+    socket.on("data", (chunk) => {
+      raw += chunk.toString("latin1");
+      if (raw.includes("\r\n\r\n")) {
+        resolveRaw(raw);
+        socket.end("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 2\r\n\r\nok");
+        server.close();
+      }
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("test server did not expose a TCP port");
+
+  const response = await sendOrderedUpstreamRequest({
+    url: `http://127.0.0.1:${address.port}/v1/messages`,
+    method: "POST",
+    headers,
+    body: "{}",
+    decompress: false,
+  });
+  const raw = await rawPromise;
+  return { raw, response };
 }
 
 describe("buildUpstreamURL", () => {
@@ -62,6 +95,41 @@ describe("buildUpstreamURL", () => {
   });
 });
 
+describe("buildZcodeTraceHeaders", () => {
+  it("emits ZCode trace headers in source order and strips internal prefixes", () => {
+    const h = buildZcodeTraceHeaders({
+      requestId: "req_1",
+      traceId: "trace_1",
+      queryId: "query_turn_1",
+      sessionId: "sess_thread_1",
+    });
+
+    expect(Object.keys(h)).toEqual(["x-request-id", "x-zcode-trace-id", "x-query-id", "x-session-id"]);
+    expect(h["x-request-id"]).toBe("req_1");
+    expect(h["x-zcode-trace-id"]).toBe("trace_1");
+    expect(h["x-query-id"]).toBe("turn_1");
+    expect(h["x-session-id"]).toBe("thread_1");
+  });
+
+  it("strips subagent session prefixes at emission time", () => {
+    const h = buildZcodeTraceHeaders({
+      requestId: "req_1",
+      traceId: "trace_1",
+      sessionId: "subagent_agent_worker_1",
+    });
+
+    expect(Object.keys(h)).toEqual(["x-request-id", "x-zcode-trace-id", "x-session-id"]);
+    expect(h["x-session-id"]).toBe("worker_1");
+  });
+
+  it("omits query and session headers when no IDs exist", () => {
+    const h = buildZcodeTraceHeaders({ requestId: "req_1", traceId: "trace_1" });
+
+    expect(Object.keys(h)).toEqual(["x-request-id", "x-zcode-trace-id"]);
+    expect(h["x-query-id"]).toBeUndefined();
+    expect(h["x-session-id"]).toBeUndefined();
+  });
+});
 describe("buildAuthHeaders", () => {
   it("injects x-api-key + anthropic-version for Anthropic", () => {
     const h = buildAuthHeaders("anthropic", ZAI_CRED, IDENTITY);
@@ -119,9 +187,39 @@ describe("buildAuthHeaders", () => {
     expect(h2["x-session-id"]).toBe("11111111-1111-4111-8111-111111111111");
     expect(h1["x-request-id"]).not.toBe(h2["x-request-id"]);
     expect(h1["x-zcode-trace-id"]).not.toBe(h2["x-zcode-trace-id"]);
-    expect(h1["x-query-id"]).not.toBe(h2["x-query-id"]);
+    expect(h1["x-query-id"]).toBeUndefined();
+    expect(h2["x-query-id"]).toBeUndefined();
   });
 
+  it("emits explicit enforced trace headers in ZCode/auth order", () => {
+    const session = {
+      source: "explicit" as const,
+      action: "enforce" as const,
+      requestId: "req_1",
+      traceId: "trace_1",
+      queryId: "query_turn_1",
+      upstreamSessionId: "sess_thread_1",
+    };
+    const h = buildAuthHeaders("anthropic", ZAI_CRED, IDENTITY, "coding-plan", session);
+
+    expect(Object.keys(h)).toEqual([
+      "HTTP-Referer",
+      "User-Agent",
+      "X-ZCode-App-Version",
+      "X-Title",
+      "X-ZCode-Agent",
+      "x-request-id",
+      "x-zcode-trace-id",
+      "x-query-id",
+      "x-session-id",
+      "x-api-key",
+      "anthropic-version",
+    ]);
+    expect(h["x-request-id"]).toBe("req_1");
+    expect(h["x-zcode-trace-id"]).toBe("trace_1");
+    expect(h["x-query-id"]).toBe("turn_1");
+    expect(h["x-session-id"]).toBe("thread_1");
+  });
   it("does not stabilize x-session-id for observe-only client sessions", () => {
     const session = { action: "observe" as const, upstreamSessionId: "11111111-1111-4111-8111-111111111111" };
     const h1 = buildAuthHeaders("openai", ZAI_CRED, IDENTITY, "coding-plan", session);
@@ -140,8 +238,75 @@ describe("buildAuthHeaders", () => {
     expect(h["x-query-id"]).toBeUndefined();
     expect(h["x-session-id"]).toBeUndefined();
   });
+
+  it("does not forward inferred start-plan session in observe mode", () => {
+    const session = {
+      source: "lineage" as const,
+      action: "observe" as const,
+      upstreamSessionId: "11111111-1111-4111-8111-111111111111",
+    };
+    const h = buildAuthHeaders("openai", { ...ZAI_CRED, jwt: "jwt-token" }, IDENTITY, "start-plan", session);
+
+    expect(h["x-request-id"]).toBeTruthy();
+    expect(h["x-zcode-trace-id"]).toBeTruthy();
+    expect(h["x-session-id"]).toBeUndefined();
+  });
+
+  it("forwards inferred start-plan session in enforce mode", () => {
+    const session = {
+      source: "lineage" as const,
+      action: "enforce" as const,
+      upstreamSessionId: "11111111-1111-4111-8111-111111111111",
+    };
+    const h = buildAuthHeaders("openai", { ...ZAI_CRED, jwt: "jwt-token" }, IDENTITY, "start-plan", session);
+
+    expect(h["x-session-id"]).toBe("11111111-1111-4111-8111-111111111111");
+  });
 });
 
+describe("sendOrderedUpstreamRequest", () => {
+  it("writes application headers in the supplied wire order", async () => {
+    const headers: Array<[string, string]> = [
+      ["content-type", "application/json"],
+      ["accept-encoding", "gzip"],
+      ["HTTP-Referer", "https://zcode.z.ai"],
+      ["User-Agent", "ZCode/test-1.0.0"],
+      ["X-ZCode-App-Version", "test-1.0.0"],
+      ["X-Title", "Z Code@cli"],
+      ["X-ZCode-Agent", "glm"],
+      ["x-request-id", "req_1"],
+      ["x-zcode-trace-id", "trace_1"],
+      ["x-query-id", "turn_1"],
+      ["x-session-id", "thread_1"],
+      ["x-api-key", "testkey.testsecret"],
+      ["anthropic-version", "2023-06-01"],
+    ];
+
+    const { raw, response } = await captureOrderedRequest(headers);
+    const requestHeaders = raw.split("\r\n\r\n")[0].split("\r\n").slice(1);
+    const appHeaders = requestHeaders.filter((line) => !/^(Host|Content-Length|Connection):/i.test(line));
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("ok");
+    expect(appHeaders).toEqual(headers.map(([k, v]) => `${k}: ${v}`));
+  });
+
+  it("rejects invalid header names and CRLF header values before writing", async () => {
+    await expect(sendOrderedUpstreamRequest({
+      url: "http://127.0.0.1:9/v1/messages",
+      method: "POST",
+      headers: [["x-request-id", "req_1\r\nx-extra: injected"]],
+      body: "{}",
+    })).rejects.toThrow(/Invalid upstream header value/);
+
+    await expect(sendOrderedUpstreamRequest({
+      url: "http://127.0.0.1:9/v1/messages",
+      method: "POST",
+      headers: [["bad header", "value"]],
+      body: "{}",
+    })).rejects.toThrow(/Invalid upstream header name/);
+  });
+});
 describe("buildUpstreamRequest", () => {
   it("constructs full Anthropic request with correct URL + headers", async () => {
     const clientReq = makeClientReq('{"model":"glm-4.6","messages":[]}');
@@ -206,6 +371,35 @@ describe("proxyRequest", () => {
     clientIdentity: { mode: "observe", ttlSeconds: 900, maxSessions: 1024 },
     logging: { level: "info" },
   };
+
+  it("uses ordered transport for session-aware start-plan requests only outside injected fetch tests", () => {
+    const startPlanConfig: ProxyConfig = { ...testConfig, plan: "start-plan" };
+
+    expect(shouldUseOrderedTransport(startPlanConfig, {
+      source: "lineage",
+      action: "observe",
+      confidence: 0.95,
+      upstreamSessionId: "11111111-1111-4111-8111-111111111111",
+    }, false)).toBe(false);
+    expect(shouldUseOrderedTransport(startPlanConfig, {
+      source: "lineage",
+      action: "enforce",
+      confidence: 0.95,
+      upstreamSessionId: "11111111-1111-4111-8111-111111111111",
+    }, false)).toBe(true);
+    expect(shouldUseOrderedTransport(startPlanConfig, {
+      source: "explicit",
+      action: "observe",
+      confidence: 1,
+      upstreamSessionId: "sess_thread_1",
+    }, false)).toBe(true);
+    expect(shouldUseOrderedTransport(startPlanConfig, {
+      source: "explicit",
+      action: "observe",
+      confidence: 1,
+      upstreamSessionId: "sess_thread_1",
+    }, true)).toBe(false);
+  });
 
   it("forwards request to upstream with injected auth", async () => {
     const fetchMock = mock(async (req: Request): Promise<Response> => {
@@ -642,6 +836,120 @@ describe("proxyRequest — regression: Anthropic passthrough unchanged", () => {
       const body = await resp.json();
       expect(body.object).toBe("chat.completion");
       expect(body.choices[0].message.content).toBe("start-plan reply");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("start-plan forwards explicit ZCode trace metadata to gateway attribution headers", async () => {
+    const startPlanConfig: ProxyConfig = {
+      ...testConfig,
+      plan: "start-plan",
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (req: Request | string): Promise<Response> => {
+      const url = typeof req === "string" ? req : req.url;
+      if (url.includes("/client/configs")) {
+        return new Response(JSON.stringify({ data: { configs: { captcha: { enabled: false } } } }), {
+          status: 200, headers: { "content-type": "application/json" },
+        });
+      }
+      throw new Error(`unexpected global fetch in test: ${url}`);
+    }) as typeof fetch;
+
+    try {
+      const fetchMock = mock(async (req: Request): Promise<Response> => {
+        expect(req.url).toBe("https://zcode.z.ai/api/v1/zcode-plan/chat/completions");
+        expect(req.headers.get("x-request-id")).toBe("req_start_1");
+        expect(req.headers.get("x-zcode-trace-id")).toBe("trace_start_1");
+        expect(req.headers.get("x-query-id")).toBe("start_query_1");
+        expect(req.headers.get("x-session-id")).toBe("start_session_1");
+        return new Response(JSON.stringify({
+          id: "chatcmpl_sp",
+          object: "chat.completion",
+          created: 1,
+          model: "glm-4.6",
+          choices: [{ index: 0, message: { role: "assistant", content: "start-plan reply" }, finish_reason: "stop" }],
+          usage: { prompt_tokens: 5, completion_tokens: 3, total_tokens: 8 },
+        }), { status: 200, headers: { "content-type": "application/json" } });
+      });
+
+      const auth = new AuthManager({ mode: "oauth", provider: "zai" });
+      auth.setOAuthCredential({ apiKey: "dummy", provider: "zai", jwt: "jwt-mock" });
+      const clientReq = new Request("http://localhost:8080/v1/chat/completions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "glm-4.6",
+          metadata: {
+            requestId: "req_start_1",
+            traceId: "trace_start_1",
+            queryId: "query_start_query_1",
+            sessionId: "sess_start_session_1",
+          },
+          messages: [{ role: "user", content: "hi" }],
+        }),
+      });
+
+      const resp = await proxyRequest(clientReq, "openai", { config: startPlanConfig, auth, fetchImpl: fetchMock as any });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(resp.status).toBe(200);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("start-plan enforce reuses inferred session through the unified resolver", async () => {
+    const startPlanConfig: ProxyConfig = {
+      ...testConfig,
+      plan: "start-plan",
+      clientIdentity: { mode: "enforce", ttlSeconds: 900, maxSessions: 1024 },
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (req: Request | string): Promise<Response> => {
+      const url = typeof req === "string" ? req : req.url;
+      if (url.includes("/client/configs")) {
+        return new Response(JSON.stringify({ data: { configs: { captcha: { enabled: false } } } }), {
+          status: 200, headers: { "content-type": "application/json" },
+        });
+      }
+      throw new Error(`unexpected global fetch in test: ${url}`);
+    }) as typeof fetch;
+
+    try {
+      const seenSessions: string[] = [];
+      const fetchMock = mock(async (req: Request): Promise<Response> => {
+        expect(req.url).toBe("https://zcode.z.ai/api/v1/zcode-plan/chat/completions");
+        seenSessions.push(req.headers.get("x-session-id") ?? "");
+        return new Response(JSON.stringify({
+          id: "chatcmpl_sp",
+          object: "chat.completion",
+          created: 1,
+          model: "glm-4.6",
+          choices: [{ index: 0, message: { role: "assistant", content: "start-plan reply" }, finish_reason: "stop" }],
+          usage: { prompt_tokens: 5, completion_tokens: 3, total_tokens: 8 },
+        }), { status: 200, headers: { "content-type": "application/json" } });
+      });
+
+      const auth = new AuthManager({ mode: "oauth", provider: "zai" });
+      auth.setOAuthCredential({ apiKey: "dummy", provider: "zai", jwt: "jwt-mock" });
+      const body = '{"model":"glm-4.6","messages":[{"role":"user","content":"hi"}]}';
+
+      const first = await proxyRequest(new Request("http://localhost:8080/v1/chat/completions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body,
+      }), "openai", { config: startPlanConfig, auth, fetchImpl: fetchMock as any });
+      const second = await proxyRequest(new Request("http://localhost:8080/v1/chat/completions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body,
+      }), "openai", { config: startPlanConfig, auth, fetchImpl: fetchMock as any });
+
+      expect(first.status).toBe(200);
+      expect(second.status).toBe(200);
+      expect(seenSessions[0]).toBeTruthy();
+      expect(seenSessions[1]).toBe(seenSessions[0]);
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/src/proxy/upstream.test.ts
+++ b/src/proxy/upstream.test.ts
@@ -698,6 +698,46 @@ describe("proxyRequest — regression: Anthropic passthrough unchanged", () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  it("does not re-solve captcha for a start-plan 403 without captcha challenge header", async () => {
+    const startPlanConfig: ProxyConfig = {
+      ...testConfig,
+      plan: "start-plan",
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (req: Request | string): Promise<Response> => {
+      const url = typeof req === "string" ? req : req.url;
+      if (url.includes("/client/configs")) {
+        return new Response(JSON.stringify({ data: { configs: { captcha: { enabled: false } } } }), {
+          status: 200, headers: { "content-type": "application/json" },
+        });
+      }
+      throw new Error(`unexpected global fetch in test: ${url}`);
+    }) as typeof fetch;
+
+    try {
+      const fetchMock = mock(async (): Promise<Response> => {
+        return new Response(JSON.stringify({ error: { type: "forbidden", message: "not captcha" } }), {
+          status: 403,
+          headers: { "content-type": "application/json" },
+        });
+      });
+
+      const auth = new AuthManager({ mode: "oauth", provider: "zai" });
+      auth.setOAuthCredential({ apiKey: "dummy", provider: "zai", jwt: "jwt-mock" });
+      const clientReq = new Request("http://localhost:8080/v1/chat/completions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: '{"model":"glm-4.6","messages":[{"role":"user","content":"hi"}]}',
+      });
+
+      const resp = await proxyRequest(clientReq, "openai", { config: startPlanConfig, auth, fetchImpl: fetchMock as any });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(resp.status).toBe(403);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });
 
 describe("proxyRequest — tool-call roundtrip (OpenAI client through Anthropic upstream)", () => {

--- a/src/proxy/upstream.ts
+++ b/src/proxy/upstream.ts
@@ -16,6 +16,11 @@ import type { ProxyIdentity } from "../config/types.js";
 import { credentialString } from "../auth/types.js";
 import { buildIdentityHeaders } from "./identity.js";
 
+export interface UpstreamClientSession {
+  action: "off" | "observe" | "enforce";
+  upstreamSessionId?: string;
+}
+
 const ANTHROPIC_VERSION = "2023-06-01";
 
 const STARTPLAN_OPENAI_BASE = "https://zcode.z.ai/api/v1/zcode-plan";
@@ -71,7 +76,13 @@ export function buildUpstreamURL(format: Format, provider: ProviderDef, plan: "c
  *
  * See module header for translation semantics.
  */
-export function buildAuthHeaders(format: Format, cred: Credential, identity: ProxyIdentity, plan: "coding-plan" | "start-plan" = "coding-plan"): Record<string, string> {
+export function buildAuthHeaders(
+  format: Format,
+  cred: Credential,
+  identity: ProxyIdentity,
+  plan: "coding-plan" | "start-plan" = "coding-plan",
+  clientSession?: UpstreamClientSession,
+): Record<string, string> {
   const credStr = plan === "start-plan" && cred.jwt ? cred.jwt : credentialString(cred);
   const base: Record<string, string> = {
     ...buildIdentityHeaders(identity),
@@ -82,7 +93,9 @@ export function buildAuthHeaders(format: Format, cred: Credential, identity: Pro
   if (plan !== "start-plan") {
     // `wdt` strips the `query_` / `sess_` internal prefixes — wire values are bare UUIDs.
     base["x-query-id"] = crypto.randomUUID();
-    base["x-session-id"] = crypto.randomUUID();
+    base["x-session-id"] = clientSession?.action === "enforce" && clientSession.upstreamSessionId
+      ? clientSession.upstreamSessionId
+      : crypto.randomUUID();
   }
 
   if (format === "anthropic") {
@@ -120,9 +133,10 @@ export function buildUpstreamRequest(
   identity: ProxyIdentity,
   plan: "coding-plan" | "start-plan" = "coding-plan",
   extraHeaders?: Record<string, string>,
+  clientSession?: UpstreamClientSession,
 ): Request {
   const url = buildUpstreamURL(format, provider, plan);
-  const authHeaders = buildAuthHeaders(format, cred, identity, plan);
+  const authHeaders = buildAuthHeaders(format, cred, identity, plan, clientSession);
   const passthrough = collectPassthroughHeaders(clientReq);
 
   const headers: Record<string, string> = {

--- a/src/proxy/upstream.ts
+++ b/src/proxy/upstream.ts
@@ -15,11 +15,20 @@ import type { Credential } from "../auth/types.js";
 import type { ProxyIdentity } from "../config/types.js";
 import { credentialString } from "../auth/types.js";
 import { buildIdentityHeaders } from "./identity.js";
+import { buildZcodeTraceHeaders } from "./trace-headers.js";
+import { sessionIdForHeader, shouldUseExactTraceHeaders } from "./session-context.js";
 
 export interface UpstreamClientSession {
+  source?: "none" | "explicit" | "lineage";
   action: "off" | "observe" | "enforce";
+  sessionId?: string;
   upstreamSessionId?: string;
+  requestId?: string;
+  traceId?: string;
+  queryId?: string;
 }
+
+export type UpstreamHeaderPair = [string, string];
 
 const ANTHROPIC_VERSION = "2023-06-01";
 
@@ -66,15 +75,10 @@ export function buildUpstreamURL(format: Format, provider: ProviderDef, plan: "c
  * - OpenAI upstream, coding-plan    → `Authorization: Bearer {cred}`
  * - OpenAI upstream, start-plan     → `Authorization: Bearer {jwt}`
  *
- * Trace/attribution headers mirror the bundle's `wdt`
- * ("createModelRequestAttributionHeaders"). That helper emits `x-request-id`
- * and `x-zcode-trace-id` unconditionally, and `x-query-id` / `x-session-id`
- * only when those IDs exist — with their internal prefixes stripped
- * (`query_`, `sess_`, `subagent_agent_`), so the wire values are bare UUIDs.
- * The proxy has no session lifecycle, so coding-plan synthesizes fresh bare
- * query/session UUIDs. Start-plan omits them when no trace context exists.
- *
- * See module header for translation semantics.
+ * Trace/attribution headers mirror the bundle's `Bdt`
+ * ("createModelRequestAttributionHeaders") when an explicit/enforced trace
+ * context exists. Default observe mode keeps the prior synthesized query/session
+ * behavior for compatibility.
  */
 export function buildAuthHeaders(
   format: Format,
@@ -86,17 +90,8 @@ export function buildAuthHeaders(
   const credStr = plan === "start-plan" && cred.jwt ? cred.jwt : credentialString(cred);
   const base: Record<string, string> = {
     ...buildIdentityHeaders(identity),
-    "x-request-id": crypto.randomUUID(),
-    "x-zcode-trace-id": crypto.randomUUID(),
+    ...buildTraceHeaders(plan, clientSession),
   };
-
-  if (plan !== "start-plan") {
-    // `wdt` strips the `query_` / `sess_` internal prefixes — wire values are bare UUIDs.
-    base["x-query-id"] = crypto.randomUUID();
-    base["x-session-id"] = clientSession?.action === "enforce" && clientSession.upstreamSessionId
-      ? clientSession.upstreamSessionId
-      : crypto.randomUUID();
-  }
 
   if (format === "anthropic") {
     if (plan === "start-plan" && cred.jwt) {
@@ -112,6 +107,27 @@ export function buildAuthHeaders(
   return base;
 }
 
+function buildTraceHeaders(plan: "coding-plan" | "start-plan", clientSession?: UpstreamClientSession): Record<string, string> {
+  if (shouldUseExactTraceHeaders(plan, clientSession)) {
+    return buildZcodeTraceHeaders({
+      requestId: clientSession?.requestId,
+      traceId: clientSession?.traceId,
+      queryId: clientSession?.queryId,
+      sessionId: sessionIdForHeader(clientSession),
+    });
+  }
+
+  const headers: Record<string, string> = {
+    "x-request-id": crypto.randomUUID(),
+    "x-zcode-trace-id": crypto.randomUUID(),
+  };
+  if (plan !== "start-plan") {
+    headers["x-query-id"] = crypto.randomUUID();
+    headers["x-session-id"] = crypto.randomUUID();
+  }
+  return headers;
+}
+
 function collectPassthroughHeaders(req: Request): Record<string, string> {
   const result: Record<string, string> = {};
   for (const [key, value] of req.headers.entries()) {
@@ -122,6 +138,24 @@ function collectPassthroughHeaders(req: Request): Record<string, string> {
     }
   }
   return result;
+}
+
+export function buildUpstreamHeaderPairs(
+  clientReq: Request,
+  format: Format,
+  cred: Credential,
+  identity: ProxyIdentity,
+  plan: "coding-plan" | "start-plan" = "coding-plan",
+  extraHeaders?: Record<string, string>,
+  clientSession?: UpstreamClientSession,
+): UpstreamHeaderPair[] {
+  return [
+    ["content-type", "application/json"],
+    ["accept-encoding", "gzip"],
+    ...Object.entries(collectPassthroughHeaders(clientReq)),
+    ...Object.entries(buildAuthHeaders(format, cred, identity, plan, clientSession)),
+    ...Object.entries(extraHeaders ?? {}),
+  ];
 }
 
 export function buildUpstreamRequest(
@@ -136,20 +170,11 @@ export function buildUpstreamRequest(
   clientSession?: UpstreamClientSession,
 ): Request {
   const url = buildUpstreamURL(format, provider, plan);
-  const authHeaders = buildAuthHeaders(format, cred, identity, plan, clientSession);
-  const passthrough = collectPassthroughHeaders(clientReq);
-
-  const headers: Record<string, string> = {
-    "content-type": "application/json",
-    "accept-encoding": "gzip",
-    ...passthrough,
-    ...authHeaders,
-    ...extraHeaders,
-  };
+  const headerPairs = buildUpstreamHeaderPairs(clientReq, format, cred, identity, plan, extraHeaders, clientSession);
 
   const init: RequestInit = {
     method: "POST",
-    headers,
+    headers: Object.fromEntries(headerPairs),
   };
 
   if (body !== undefined) {

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -22,6 +22,7 @@ function makeConfig(overrides: Partial<ProxyConfig> = {}): ProxyConfig {
     defaultModel: "glm-4.6",
     models: ["glm-4.6"],
     identity: { appVersion: "test-1.0.0", sourceTitle: "cli", refererOrigin: "https://zcode.z.ai" },
+    clientIdentity: { mode: "observe", ttlSeconds: 900, maxSessions: 1024 },
     logging: { level: "info" },
     ...overrides,
   };

--- a/src/translator/AGENTS.md
+++ b/src/translator/AGENTS.md
@@ -1,0 +1,38 @@
+# src/translator
+
+Bidirectional OpenAI ↔ Anthropic translation: request bodies, response bodies, and SSE
+streams. Only invoked in **translation mode** (OpenAI client → Anthropic upstream); Anthropic
+requests pass through untouched. The hot path is `openai-to-anthropic.ts` +
+`sse-translator.ts`, called from `proxy/handler.ts`.
+
+## STRUCTURE
+```
+translator/
+├── types.ts                  # Format, OpenAIChatRequest, AnthropicMessagesResponse, etc.
+├── openai-to-anthropic.ts    # request OpenAI→Anthropic + response Anthropic→OpenAI (batch)
+├── anthropic-to-openai.ts    # the reverse direction (request Anthropic→OpenAI + response)
+├── sse-translator.ts         # SSE stream translation: anthropicSseToOpenaiSse / reverse
+├── openai-to-anthropic.test.ts
+└── sse-translator.test.ts
+```
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| Translate a new OpenAI request field | `openai-to-anthropic.ts:translateRequestOpenAIToAnthropic` | maps messages, tools, tool_choice, system, max_tokens |
+| Translate a new response field | `openai-to-anthropic.ts:translateResponseAnthropicToOpenAI` | content blocks → choices, usage, stop_reason→finish_reason |
+| Change SSE event mapping | `sse-translator.ts` | message_start/content_block_delta/message_stop → OpenAI chunks |
+| Add/adjust a shared type | `types.ts` | `Format = "openai" \| "anthropic"` is imported across proxy too |
+| Fix a streaming crash | `sse-translator.ts` | the `error()`/`close()` mutex — see ANTI-PATTERNS + root #1 |
+
+## CONVENTIONS
+- **Translation is lossless-by-intent but lossy-in-practice for deltas.** SSE chunk translation reconstructs OpenAI `choices[0].delta` from Anthropic `content_block_delta`; some Anthropic event types (e.g. `ping`, `message_delta` usage) map to `[DONE]`/usage only.
+- **Consecutive `role:"tool"` messages coalesce into ONE Anthropic `user` turn** with multiple `tool_result` blocks (`openai-to-anthropic.ts`). Anthropic rejects adjacent tool messages — keep the coalescing.
+- **Usage mapping:** Anthropic `input_tokens`/`output_tokens` → OpenAI `prompt_tokens`/`completion_tokens`; `stop_reason` → `finish_reason` (`end_turn`→`stop`, `tool_use`→`tool_calls`, …).
+- **SSE translator runs on a `tee()`'d stream** — one branch goes to the client, the other to `handler.observeStream` for stats. Don't consume the input stream inside the translator.
+- **`Format` is the routing key,** not just a label: `proxy/handler.ts` sets `upstreamFormat = translateMode ? "anthropic" : format`. Adding a format ripples through the whole pipeline.
+
+## ANTI-PATTERNS
+- **NEVER `controller.close()` after `controller.error()`** (`sse-translator.ts`). They're mutually exclusive on a `ReadableStreamController`; calling `close()` post-error throws `TypeError` and crashes Bun. Guard with an `errored` flag in every `pull`/`cancel`/`finally`. (This is root anti-pattern #1 — it lives here.)
+- **Don't emit OpenAI chunks without a leading `role` delta.** OpenAI clients expect `choices[0].delta.role="assistant"` before content deltas; mirror `@ai-sdk/openai-compatible`.
+- **Don't buffer the whole SSE stream** — translate incrementally inside `pull()`; the proxy streams to the client as bytes arrive.


### PR DESCRIPTION
## Summary
- Preserve explicit request, trace, query, and session IDs instead of hashing them away
- Route session-aware start-plan requests through ordered upstream transport so header emission matches the expected wire order
- Add coverage for explicit metadata, lineage reuse, trace header emission, and transport selection

## Testing
- Added unit tests for client session resolution, trace header building, ordered transport validation, and upstream header behavior
- Added proxy integration coverage for start-plan attribution and inferred session reuse