### PR TITLE
teach the protocol translators to carry tool calls and usage end to end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 /zcode-proxy.exe
 /zcode-proxy-linux-*
 /zcode-proxy-darwin-*
+.idea/

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -154,6 +154,8 @@ beforeAll(() => {
             '',
             'data: {"id":"chatcmpl-int-stream","object":"chat.completion.chunk","created":1,"model":"glm-4.6","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
             '',
+            'data: {"id":"chatcmpl-int-stream","object":"chat.completion.chunk","created":1,"model":"glm-4.6","choices":[],"usage":{"prompt_tokens":33,"completion_tokens":4,"total_tokens":37}}',
+            '',
             'data: [DONE]',
             '',
           ].join("\n");
@@ -258,6 +260,33 @@ describe("integration: OpenAI streaming passthrough", () => {
   });
 });
 
+describe("integration: Anthropic streaming usage", () => {
+  it("delivers real input_tokens via message_delta (not stuck at 0)", async () => {
+    const resp = await fetch(proxyUrl("/v1/messages"), {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify({
+        model: "glm-4.6",
+        max_tokens: 100,
+        stream: true,
+        messages: [{ role: "user", content: "Stream test" }],
+      }),
+    });
+    expect(resp.status).toBe(200);
+    const text = await resp.text();
+
+    // Parse the message_delta event and assert usage carries the upstream's
+    // prompt_tokens (33) as input_tokens — the regression was that this was 0
+    // because message_start fired before the usage chunk arrived.
+    const deltaLine = text.split("\n").find((l) => l.startsWith("data: ") && l.includes('"message_delta"'));
+    expect(deltaLine).toBeDefined();
+    const delta = JSON.parse(deltaLine!.slice(6));
+    expect(delta.usage.input_tokens).toBe(33);
+    expect(delta.usage.output_tokens).toBe(4);
+    expect(text).toContain("event: message_stop");
+  });
+});
+
 describe("integration: OpenAI tool-call roundtrip (HTTP layer)", () => {
   it("returns OpenAI tool_calls on turn 1, accepts tool_result on turn 2, upstream receives OpenAI shape", async () => {
     const tools = [{ type: "function", function: { name: "get_weather", parameters: { type: "object", properties: { city: { type: "string" } } } } }];
@@ -329,6 +358,60 @@ describe("integration: Anthropic compatibility", () => {
     const body = await resp.json();
     expect(body.content[0].text).toBe("OpenAI integration response");
     expect(body.stop_reason).toBe("end_turn");
+  });
+
+  it("round-trips Anthropic tool_use → tool_result through the OpenAI upstream", async () => {
+    const tools = [{ name: "get_weather", description: "Get weather", input_schema: { type: "object", properties: { city: { type: "string" } } } }];
+
+    // Turn 1: Anthropic client asks for a tool call.
+    const resp1 = await fetch(proxyUrl("/v1/messages"), {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify({
+        model: "glm-4.6",
+        max_tokens: 100,
+        messages: [{ role: "user", content: "weather in SF?" }],
+        tools,
+        tool_choice: { type: "auto" },
+      }),
+    });
+    expect(resp1.status).toBe(200);
+    const body1 = await resp1.json();
+    expect(body1.stop_reason).toBe("tool_use");
+    const toolUse = body1.content.find((b: any) => b.type === "tool_use");
+    expect(toolUse).toBeDefined();
+    expect(toolUse.name).toBe("get_weather");
+    expect(toolUse.input).toEqual({ city: "SF" });
+
+    // Turn 2: Anthropic client replays tool_result history; upstream must see
+    // the OpenAI shape (assistant tool_calls + role:"tool" messages).
+    const resp2 = await fetch(proxyUrl("/v1/messages"), {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify({
+        model: "glm-4.6",
+        max_tokens: 100,
+        messages: [
+          { role: "user", content: "weather in SF?" },
+          { role: "assistant", content: [toolUse] },
+          { role: "user", content: [{ type: "tool_result", tool_use_id: toolUse.id, content: "62°F" }] },
+        ],
+        tools,
+      }),
+    });
+    expect(resp2.status).toBe(200);
+    const body2 = await resp2.json();
+    expect(body2.stop_reason).toBe("end_turn");
+    expect(body2.content[0].text).toBe("Tool result acknowledged");
+
+    const upstreamReq = capturedUpstreamBodies
+      .map((b) => JSON.parse(b))
+      .filter((b) => (b.messages ?? []).some((m: any) => m.role === "tool" && m.tool_call_id === toolUse.id))
+      .at(-1);
+    expect(upstreamReq).toBeDefined();
+    expect(upstreamReq.messages.map((m: any) => m.role)).toEqual(["user", "assistant", "tool"]);
+    expect(upstreamReq.messages[1].tool_calls[0].function.name).toBe("get_weather");
+    expect(upstreamReq.messages[2]).toMatchObject({ role: "tool", tool_call_id: toolUse.id, content: "62°F" });
   });
 });
 

--- a/src/translator/anthropic-to-openai.ts
+++ b/src/translator/anthropic-to-openai.ts
@@ -5,11 +5,15 @@
 import type {
   OpenAIChatRequest,
   OpenAIChatResponse,
+  OpenAIUsage,
   OpenAIMessage,
+  OpenAIContentPart,
+  OpenAIToolCall,
   AnthropicMessagesRequest,
   AnthropicMessagesResponse,
   AnthropicMessage,
   AnthropicContentBlock,
+  AnthropicUsage,
 } from "./types.js";
 
 /** Translate an Anthropic messages request into an OpenAI chat request. */
@@ -24,7 +28,7 @@ export function translateRequestAnthropicToOpenAI(req: AnthropicMessagesRequest)
   }
 
   for (const m of req.messages) {
-    messages.push(translateMessageAnthropicToOpenAI(m));
+    messages.push(...translateMessageAnthropicToOpenAI(m));
   }
 
   const result: OpenAIChatRequest = {
@@ -55,7 +59,40 @@ export function translateRequestAnthropicToOpenAI(req: AnthropicMessagesRequest)
     }));
   }
 
+  if (req.tool_choice) {
+    const translated = mapToolChoiceAnthropicToOpenAI(req.tool_choice);
+    if (translated !== undefined) result.tool_choice = translated;
+  }
+
   return result;
+}
+
+/**
+ * Map an Anthropic `tool_choice` to the OpenAI Chat Completions form.
+ *
+ * Anthropic: `{type:"auto"|"any"|"tool", name?}` (a top-level string is also
+ * accepted by the API). There is no `none` — suppressing tools is done by
+ * omitting the `tools` array entirely.
+ * OpenAI:    `"auto" | "required"` or `{type:"function", function:{name}}`.
+ * Note: Anthropic `any` (force some tool) maps to OpenAI `required`.
+ */
+function mapToolChoiceAnthropicToOpenAI(
+  choice: { type: "auto" | "any" | "tool"; name?: string },
+): "auto" | "required" | { type: "function"; function: { name: string | undefined } } | undefined {
+  switch (choice.type) {
+    case "auto":
+      return "auto";
+    case "any":
+      return "required";
+    case "tool":
+      // Pass `name` through verbatim (possibly undefined). Anthropic mandates a
+      // name for type:"tool", so a missing one is a client contract violation —
+      // forwarding it lets the upstream reject with its native error rather than
+      // masking the bug behind a synthetic empty function name.
+      return { type: "function", function: { name: choice.name } };
+    default:
+      return undefined;
+  }
 }
 
 /** Translate an OpenAI chat response into an Anthropic messages response. */
@@ -100,32 +137,120 @@ export function translateResponseOpenAIToAnthropic(
     model: resp.model,
     stop_reason: stopReason,
     stop_sequence: null,
-    usage: {
-      input_tokens: resp.usage?.prompt_tokens ?? 0,
-      output_tokens: resp.usage?.completion_tokens ?? 0,
-    },
+    usage: openaiUsageToAnthropic(resp.usage),
   };
 }
 
-function translateMessageAnthropicToOpenAI(m: AnthropicMessage): OpenAIMessage {
+/**
+ * Translate a single Anthropic message into one or more OpenAI messages.
+ *
+ * A single Anthropic message can fan out to multiple OpenAI messages because
+ * `tool_result` blocks must become standalone `role:"tool"` messages (OpenAI
+ * has no inline equivalent). The carrier message (text/image/tool_use) is
+ * emitted last, preserving the Anthropic role for text/assistant content.
+ */
+function translateMessageAnthropicToOpenAI(m: AnthropicMessage): OpenAIMessage[] {
   if (typeof m.content === "string") {
-    return { role: m.role, content: m.content };
+    return [{ role: m.role, content: m.content }];
   }
 
-  const textParts = m.content
-    .filter((b) => b.type === "text")
-    .map((b) => (b as any).text)
-    .join("");
-  const thinkingParts = m.content
-    .filter((b) => b.type === "thinking")
-    .map((b) => (b as any).thinking ?? "")
-    .join("");
+  const result: OpenAIMessage[] = [];
+  const contentParts: OpenAIContentPart[] = [];
+  const toolCalls: OpenAIToolCall[] = [];
+  const reasoningParts: string[] = [];
 
-  return {
-    role: m.role,
-    content: textParts || null,
-    ...(m.role === "assistant" && thinkingParts ? { reasoning_content: thinkingParts } : {}),
-  };
+  for (const block of m.content) {
+    switch (block.type) {
+      case "text": {
+        contentParts.push({ type: "text", text: block.text });
+        break;
+      }
+      case "image": {
+        if (block.source.type === "base64") {
+          contentParts.push({
+            type: "image_url",
+            image_url: { url: `data:${block.source.media_type};base64,${block.source.data}` },
+          });
+        }
+        break;
+      }
+      case "tool_use": {
+        toolCalls.push({
+          id: block.id,
+          type: "function",
+          function: { name: block.name, arguments: JSON.stringify(block.input ?? {}) },
+        });
+        break;
+      }
+      case "tool_result": {
+        result.push({
+          role: "tool",
+          tool_call_id: block.tool_use_id,
+          content: toolResultContentToOpenAI(block.content, block.is_error === true),
+        });
+        break;
+      }
+      case "thinking": {
+        if (block.thinking.length > 0) reasoningParts.push(block.thinking);
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  // Emit the carrier message when there is text/image content, tool calls, or
+  // assistant reasoning — otherwise a thinking-only assistant turn would lose
+  // its reasoning_content (and the next user turn would be misaligned).
+  const hasReasoning = m.role === "assistant" && reasoningParts.length > 0;
+  if (contentParts.length > 0 || toolCalls.length > 0 || hasReasoning) {
+    const content: string | null | OpenAIContentPart[] = contentParts.length === 0
+      ? null
+      : contentParts.length === 1 && contentParts[0].type === "text"
+        ? contentParts[0].text ?? ""
+        : contentParts;
+    result.push({
+      role: m.role,
+      content,
+      ...(hasReasoning ? { reasoning_content: reasoningParts.join("\n") } : {}),
+      ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
+    });
+  }
+
+  // Guarantee at least one message so the turn isn't silently dropped.
+  if (result.length === 0) {
+    result.push({ role: m.role, content: null });
+  }
+
+  return result;
+}
+
+/**
+ * Flatten an Anthropic tool_result `content` field into an OpenAI tool-message
+ * `content` string. Text blocks are joined; non-text blocks are JSON-serialized
+ * to avoid data loss (OpenAI tool messages are stringly-typed).
+ *
+ * OpenAI has no native "this tool call failed" flag, so a truthy `isError`
+ * (Anthropic's `tool_result.is_error`) is encoded as a leading `[tool_error]`
+ * marker so the downstream model can still tell a failed execution from a
+ * successful one.
+ */
+function toolResultContentToOpenAI(
+  content: string | AnthropicContentBlock[] | undefined,
+  isError: boolean,
+): string {
+  const body = flattenToolResultContent(content);
+  return isError && body.length > 0 ? `[tool_error] ${body}` : body;
+}
+
+function flattenToolResultContent(content: string | AnthropicContentBlock[] | undefined): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  const texts = content
+    .filter((b) => b.type === "text")
+    .map((b) => b.text);
+  if (texts.length > 0) return texts.join("");
+  return JSON.stringify(content);
 }
 
 function mapFinishReasonToStopReason(
@@ -143,4 +268,31 @@ function mapFinishReasonToStopReason(
     default:
       return null;
   }
+}
+
+/**
+ * Convert an OpenAI usage block into Anthropic usage semantics.
+ *
+ * OpenAI `prompt_tokens` is *inclusive* of cache hits, while Anthropic
+ * `input_tokens` is the fresh (uncached) input. The three buckets are mutually
+ * exclusive and sum to `prompt_tokens`: `input + cache_read + cache_creation`.
+ * Cache values are accepted from either the standard `prompt_tokens_details`
+ * breakdown or Anthropic-style direct fields (some compatible upstreams emit
+ * those). Missing buckets default to 0, so a vanilla OpenAI usage with no cache
+ * fields passes through unchanged.
+ */
+export function openaiUsageToAnthropic(usage: OpenAIUsage | undefined): AnthropicUsage {
+  const promptTokens = usage?.prompt_tokens ?? 0;
+  const cacheRead = usage?.cache_read_input_tokens
+    ?? usage?.prompt_tokens_details?.cached_tokens
+    ?? 0;
+  const cacheCreation = usage?.cache_creation_input_tokens ?? 0;
+  const inputTokens = Math.max(0, promptTokens - cacheRead - cacheCreation);
+  const result: AnthropicUsage = {
+    input_tokens: inputTokens,
+    output_tokens: usage?.completion_tokens ?? 0,
+  };
+  if (cacheRead > 0) result.cache_read_input_tokens = cacheRead;
+  if (cacheCreation > 0) result.cache_creation_input_tokens = cacheCreation;
+  return result;
 }

--- a/src/translator/openai-to-anthropic.test.ts
+++ b/src/translator/openai-to-anthropic.test.ts
@@ -578,6 +578,235 @@ describe("translateRequestAnthropicToOpenAI", () => {
       reasoning_content: "I should reason first.",
     });
   });
+
+  it("preserves reasoning_content for a thinking-only assistant message (no text/tool_use)", () => {
+    const req: AnthropicMessagesRequest = {
+      model: "glm-5.2",
+      messages: [{
+        role: "assistant",
+        content: [{ type: "thinking", thinking: "Just thinking, no answer yet." }],
+      }],
+      max_tokens: 100,
+    };
+
+    const result = translateRequestAnthropicToOpenAI(req);
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]).toEqual({
+      role: "assistant",
+      content: null,
+      reasoning_content: "Just thinking, no answer yet.",
+    });
+  });
+
+  it("translates assistant tool_use blocks into OpenAI tool_calls", () => {
+    const req: AnthropicMessagesRequest = {
+      model: "glm-4.6",
+      max_tokens: 100,
+      messages: [
+        { role: "user", content: "weather in SF?" },
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Let me check." },
+            { type: "tool_use", id: "toolu_1", name: "get_weather", input: { city: "SF" } },
+          ],
+        },
+      ],
+    };
+
+    const result = translateRequestAnthropicToOpenAI(req);
+    const assistant = result.messages[1];
+    expect(assistant.role).toBe("assistant");
+    expect(assistant.content).toBe("Let me check.");
+    expect(assistant.tool_calls).toEqual([{
+      id: "toolu_1",
+      type: "function",
+      function: { name: "get_weather", arguments: '{"city":"SF"}' },
+    }]);
+  });
+
+  it("translates user tool_result blocks into standalone role:'tool' messages", () => {
+    const req: AnthropicMessagesRequest = {
+      model: "glm-4.6",
+      max_tokens: 100,
+      messages: [
+        { role: "user", content: "weather?" },
+        {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "toolu_1", name: "get_weather", input: { city: "SF" } }],
+        },
+        {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "toolu_1", content: "62°F and sunny" }],
+        },
+      ],
+    };
+
+    const result = translateRequestAnthropicToOpenAI(req);
+    expect(result.messages.map((m) => m.role)).toEqual(["user", "assistant", "tool"]);
+    const toolMsg = result.messages[2];
+    expect(toolMsg).toEqual({
+      role: "tool",
+      tool_call_id: "toolu_1",
+      content: "62°F and sunny",
+    });
+  });
+
+  it("coalesces parallel tool_result blocks into multiple role:'tool' messages", () => {
+    const req: AnthropicMessagesRequest = {
+      model: "glm-4.6",
+      max_tokens: 100,
+      messages: [
+        { role: "user", content: "weather in SF and NYC" },
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "toolu_a", name: "get_weather", input: { city: "SF" } },
+            { type: "tool_use", id: "toolu_b", name: "get_weather", input: { city: "NYC" } },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "toolu_a", content: "62°F" },
+            { type: "tool_result", tool_use_id: "toolu_b", content: "58°F" },
+          ],
+        },
+      ],
+    };
+
+    const result = translateRequestAnthropicToOpenAI(req);
+    expect(result.messages.map((m) => m.role)).toEqual(["user", "assistant", "tool", "tool"]);
+    expect(result.messages[2]).toMatchObject({ role: "tool", tool_call_id: "toolu_a", content: "62°F" });
+    expect(result.messages[3]).toMatchObject({ role: "tool", tool_call_id: "toolu_b", content: "58°F" });
+  });
+
+  it("translates tool_choice {type:'any'} to OpenAI 'required'", () => {
+    const req: AnthropicMessagesRequest = {
+      model: "glm-4.6",
+      max_tokens: 100,
+      messages: [{ role: "user", content: "Hi" }],
+      tools: [{ name: "fn", input_schema: { type: "object" } }],
+      tool_choice: { type: "any" },
+    };
+
+    const result = translateRequestAnthropicToOpenAI(req);
+
+    expect(result.tool_choice).toBe("required");
+  });
+
+  it("translates tool_choice {type:'tool', name} to OpenAI function selector", () => {
+    const req: AnthropicMessagesRequest = {
+      model: "glm-4.6",
+      max_tokens: 100,
+      messages: [{ role: "user", content: "Hi" }],
+      tools: [{ name: "specific_tool", input_schema: { type: "object" } }],
+      tool_choice: { type: "tool", name: "specific_tool" },
+    };
+
+    const result = translateRequestAnthropicToOpenAI(req);
+
+    expect(result.tool_choice).toEqual({ type: "function", function: { name: "specific_tool" } });
+  });
+
+  it("translates tool_choice {type:'auto'} to OpenAI 'auto'", () => {
+    const req: AnthropicMessagesRequest = {
+      model: "glm-4.6",
+      max_tokens: 100,
+      messages: [{ role: "user", content: "Hi" }],
+      tools: [{ name: "fn", input_schema: { type: "object" } }],
+      tool_choice: { type: "auto" },
+    };
+
+    const result = translateRequestAnthropicToOpenAI(req);
+
+    expect(result.tool_choice).toBe("auto");
+  });
+
+  it("serializes non-text tool_result content (e.g. image) as JSON to avoid data loss", () => {
+    const req: AnthropicMessagesRequest = {
+      model: "glm-4.6",
+      max_tokens: 100,
+      messages: [
+        { role: "user", content: "x" },
+        { role: "assistant", content: [{ type: "tool_use", id: "t1", name: "fn", input: {} }] },
+        {
+          role: "user",
+          content: [{
+            type: "tool_result",
+            tool_use_id: "t1",
+            content: [{ type: "image", source: { type: "base64", media_type: "image/png", data: "iVBORw0KGgo=" } }],
+          }],
+        },
+      ],
+    };
+
+    const result = translateRequestAnthropicToOpenAI(req);
+    const toolMsg = result.messages[2];
+    expect(toolMsg.role).toBe("tool");
+    expect(typeof toolMsg.content).toBe("string");
+    expect(toolMsg.content).toContain("image/png");
+  });
+
+  it("encodes tool_result.is_error=true as a [tool_error] prefix on the OpenAI tool message", () => {
+    const req: AnthropicMessagesRequest = {
+      model: "glm-4.6",
+      max_tokens: 100,
+      messages: [
+        { role: "user", content: "x" },
+        { role: "assistant", content: [{ type: "tool_use", id: "t1", name: "fn", input: {} }] },
+        {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "t1", content: "command not found", is_error: true }],
+        },
+      ],
+    };
+
+    const result = translateRequestAnthropicToOpenAI(req);
+    const toolMsg = result.messages[2];
+    expect(toolMsg.role).toBe("tool");
+    expect(toolMsg.content).toBe("[tool_error] command not found");
+  });
+
+  it("does not add [tool_error] prefix when is_error is absent or false", () => {
+    const req: AnthropicMessagesRequest = {
+      model: "glm-4.6",
+      max_tokens: 100,
+      messages: [
+        { role: "user", content: "x" },
+        { role: "assistant", content: [{ type: "tool_use", id: "t1", name: "fn", input: {} }] },
+        {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "t1", content: "ok" },
+            { type: "tool_result", tool_use_id: "t2", content: "still ok", is_error: false },
+          ],
+        },
+      ],
+    };
+
+    const result = translateRequestAnthropicToOpenAI(req);
+    expect(result.messages[2].content).toBe("ok");
+    expect(result.messages[3].content).toBe("still ok");
+  });
+
+  it("preserves tool_choice {type:'tool'} without name by forwarding undefined (no synthetic empty name)", () => {
+    // Client contract violation (Anthropic requires name for type:"tool"), but
+    // the proxy must not mask it as an empty function name — forward as-is so
+    // the upstream surfaces the original error.
+    const req = {
+      model: "glm-4.6",
+      max_tokens: 100,
+      messages: [{ role: "user", content: "Hi" }],
+      tools: [{ name: "fn", input_schema: { type: "object" } }],
+      tool_choice: { type: "tool" },
+    } as unknown as AnthropicMessagesRequest;
+
+    const result = translateRequestAnthropicToOpenAI(req);
+
+    expect(result.tool_choice).toEqual({ type: "function", function: { name: undefined } });
+  });
 });
 
 describe("translateResponseOpenAIToAnthropic", () => {
@@ -640,5 +869,72 @@ describe("translateResponseOpenAIToAnthropic", () => {
 
     expect(result.content[0]).toEqual({ type: "thinking", thinking: "I should answer directly." });
     expect(result.content[1]).toEqual({ type: "text", text: "Hi" });
+  });
+
+  it("maps usage tokens correctly", () => {
+    const resp: OpenAIChatResponse = {
+      id: "chatcmpl-1",
+      object: "chat.completion",
+      created: 1234567890,
+      model: "glm-4.6",
+      choices: [{
+        index: 0,
+        message: { role: "assistant", content: "Hi" },
+        finish_reason: "stop",
+      }],
+      usage: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 },
+    };
+    const result = translateResponseOpenAIToAnthropic(resp);
+    expect(result.usage.input_tokens).toBe(100);
+    expect(result.usage.output_tokens).toBe(50);
+  });
+
+  it("subtracts cached tokens from input_tokens and reports cache buckets (prompt_tokens_details)", () => {
+    const resp: OpenAIChatResponse = {
+      id: "chatcmpl-1",
+      object: "chat.completion",
+      created: 1234567890,
+      model: "glm-4.6",
+      choices: [{
+        index: 0,
+        message: { role: "assistant", content: "Hi" },
+        finish_reason: "stop",
+      }],
+      usage: {
+        prompt_tokens: 1000,
+        completion_tokens: 10,
+        total_tokens: 1010,
+        prompt_tokens_details: { cached_tokens: 700 },
+      },
+    };
+    const result = translateResponseOpenAIToAnthropic(resp);
+    expect(result.usage.input_tokens).toBe(300); // 1000 - 700
+    expect(result.usage.output_tokens).toBe(10);
+    expect(result.usage.cache_read_input_tokens).toBe(700);
+  });
+
+  it("subtracts both cache_read and cache_creation from input_tokens", () => {
+    const resp: OpenAIChatResponse = {
+      id: "chatcmpl-1",
+      object: "chat.completion",
+      created: 1234567890,
+      model: "glm-4.6",
+      choices: [{
+        index: 0,
+        message: { role: "assistant", content: "Hi" },
+        finish_reason: "stop",
+      }],
+      usage: {
+        prompt_tokens: 500,
+        completion_tokens: 5,
+        total_tokens: 505,
+        cache_read_input_tokens: 200,
+        cache_creation_input_tokens: 100,
+      },
+    };
+    const result = translateResponseOpenAIToAnthropic(resp);
+    expect(result.usage.input_tokens).toBe(200); // 500 - 200 - 100
+    expect(result.usage.cache_read_input_tokens).toBe(200);
+    expect(result.usage.cache_creation_input_tokens).toBe(100);
   });
 });

--- a/src/translator/openai-to-anthropic.ts
+++ b/src/translator/openai-to-anthropic.ts
@@ -81,7 +81,7 @@ function isReasoningModel(model: string): boolean {
 }
 
 function translateToolChoice(
-  choice: "none" | "auto" | "required" | { type: "function"; function: { name: string } },
+  choice: "none" | "auto" | "required" | { type: "function"; function: { name: string | undefined } },
 ): { type: "auto" | "any" | "tool"; name?: string } | undefined {
   if (choice === "auto") return { type: "auto" };
   if (choice === "required") return { type: "any" };

--- a/src/translator/sse-translator.test.ts
+++ b/src/translator/sse-translator.test.ts
@@ -482,4 +482,210 @@ describe("openaiSseToAnthropicSse", () => {
     const output = await collectStream(openaiSseToAnthropicSse(input, "glm-4.6"));
     expect(output).toContain("message_stop");
   });
+
+  it("translates OpenAI tool_calls delta into Anthropic tool_use content_block_start + input_json_delta", async () => {
+    const sse = [
+      'data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"glm-4.6","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}',
+      '',
+      'data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"glm-4.6","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"get_weather","arguments":""}}]},"finish_reason":null}]}',
+      '',
+      'data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"glm-4.6","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"city\\":"}}]},"finish_reason":null}]}',
+      '',
+      'data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"glm-4.6","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\\"SF\\"}"}}]},"finish_reason":null}]}',
+      '',
+      'data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"glm-4.6","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}',
+      '',
+      'data: [DONE]',
+      '',
+    ].join('\n');
+
+    const output = await collectStream(openaiSseToAnthropicSse(makeStream(sse), "glm-4.6"));
+    const events = parseAnthropicEvents(output);
+
+    const blockStarts = events.filter((e) => e.event === "content_block_start");
+    const toolStart = blockStarts.find((e) => e.data.content_block?.type === "tool_use");
+    expect(toolStart).toBeDefined();
+    expect(toolStart!.data.content_block).toEqual({
+      type: "tool_use",
+      id: "call_1",
+      name: "get_weather",
+      input: {},
+    });
+
+    const jsonDeltas = events.filter((e) => e.data.delta?.type === "input_json_delta");
+    expect(jsonDeltas.map((e) => e.data.delta.partial_json).join("")).toBe('{"city":"SF"}');
+
+    const blockStops = events.filter((e) => e.event === "content_block_stop" && e.data.index === toolStart!.data.index);
+    expect(blockStops).toHaveLength(1);
+
+    const messageDelta = events.find((e) => e.event === "message_delta");
+    expect(messageDelta!.data.delta.stop_reason).toBe("tool_use");
+  });
+
+  it("routes parallel OpenAI tool_calls by index into separate Anthropic tool_use blocks", async () => {
+    const sse = [
+      'data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"glm-4.6","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_a","type":"function","function":{"name":"w","arguments":"{}"}}]},"finish_reason":null}]}',
+      '',
+      'data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"glm-4.6","choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"id":"call_b","type":"function","function":{"name":"w","arguments":"{}"}}]},"finish_reason":null}]}',
+      '',
+      'data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"glm-4.6","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}',
+      '',
+      'data: [DONE]',
+      '',
+    ].join('\n');
+
+    const output = await collectStream(openaiSseToAnthropicSse(makeStream(sse), "glm-4.6"));
+    const events = parseAnthropicEvents(output);
+    const toolStarts = events.filter((e) => e.event === "content_block_start" && e.data.content_block?.type === "tool_use");
+
+    expect(toolStarts).toHaveLength(2);
+    expect(toolStarts[0].data.content_block.id).toBe("call_a");
+    expect(toolStarts[1].data.content_block.id).toBe("call_b");
+    expect(toolStarts[0].data.index).not.toBe(toolStarts[1].data.index);
+  });
+
+  it("buffers tool_call arguments that arrive before id/name and flushes them on block start", async () => {
+    // Non-standard ordering: arguments delta first, id+name later.
+    const sse = [
+      'data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"glm-4.6","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"city\\":"}}]},"finish_reason":null}]}',
+      '',
+      'data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"glm-4.6","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_late","type":"function","function":{"name":"get_weather","arguments":"\\"SF\\"}"}}]},"finish_reason":null}]}',
+      '',
+      'data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"glm-4.6","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}',
+      '',
+      'data: [DONE]',
+      '',
+    ].join('\n');
+
+    const output = await collectStream(openaiSseToAnthropicSse(makeStream(sse), "glm-4.6"));
+    const events = parseAnthropicEvents(output);
+    const toolStart = events.find((e) => e.event === "content_block_start" && e.data.content_block?.type === "tool_use");
+    expect(toolStart).toBeDefined();
+    expect(toolStart!.data.content_block.id).toBe("call_late");
+    expect(toolStart!.data.content_block.name).toBe("get_weather");
+
+    const jsonDeltas = events.filter((e) => e.data.delta?.type === "input_json_delta");
+    expect(jsonDeltas.map((e) => e.data.delta.partial_json).join("")).toBe('{"city":"SF"}');
+  });
+
+  it("force-opens a tool block with fallback id/name when arguments arrive but id/name never do", async () => {
+    const sse = [
+      'data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"glm-4.6","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{}"}}]},"finish_reason":null}]}',
+      '',
+      'data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"glm-4.6","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}',
+      '',
+      'data: [DONE]',
+      '',
+    ].join('\n');
+
+    const output = await collectStream(openaiSseToAnthropicSse(makeStream(sse), "glm-4.6"));
+    const events = parseAnthropicEvents(output);
+    const toolStart = events.find((e) => e.event === "content_block_start" && e.data.content_block?.type === "tool_use");
+    expect(toolStart).toBeDefined();
+    expect(toolStart!.data.content_block.id).toBe("tool_call_0");
+    expect(toolStart!.data.content_block.name).toBe("unknown_tool");
+    const jsonDeltas = events.filter((e) => e.data.delta?.type === "input_json_delta");
+    expect(jsonDeltas.map((e) => e.data.delta.partial_json).join("")).toBe("{}");
+  });
+
+  it("closes the text block before opening a tool_use block (no interleaved blocks)", async () => {
+    const sse = [
+      'data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"glm-4.6","choices":[{"index":0,"delta":{"content":"Thinking about it"},"finish_reason":null}]}',
+      '',
+      'data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"glm-4.6","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"fn","arguments":"{}"}}]},"finish_reason":null}]}',
+      '',
+      'data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"glm-4.6","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}',
+      '',
+      'data: [DONE]',
+      '',
+    ].join('\n');
+
+    const output = await collectStream(openaiSseToAnthropicSse(makeStream(sse), "glm-4.6"));
+    const events = parseAnthropicEvents(output);
+    const textStart = events.find((e) => e.event === "content_block_start" && e.data.content_block?.type === "text");
+    const toolStart = events.find((e) => e.event === "content_block_start" && e.data.content_block?.type === "tool_use");
+    const textStop = events.find((e) => e.event === "content_block_stop" && e.data.index === textStart!.data.index);
+
+    expect(textStart).toBeDefined();
+    expect(toolStart).toBeDefined();
+    // text block must stop before tool block starts
+    const textStopOrder = events.indexOf(textStop!);
+    const toolStartOrder = events.indexOf(toolStart!);
+    expect(textStopOrder).toBeLessThan(toolStartOrder);
+  });
+
+  it("emits a well-formed message_stop when stream ends without [DONE]", async () => {
+    const sse = [
+      'data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"glm-4.6","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}',
+      '',
+    ].join('\n');
+
+    const output = await collectStream(openaiSseToAnthropicSse(makeStream(sse), "glm-4.6"));
+    const events = parseAnthropicEvents(output);
+    expect(events.some((e) => e.event === "message_delta")).toBe(true);
+    expect(events.some((e) => e.event === "message_stop")).toBe(true);
+  });
+
+  it("reports real input_tokens via message_delta when usage only arrives in the final chunk", async () => {
+    // OpenAI include_usage stream: usage lands on a trailing choices-less chunk
+    // AFTER the finish_reason chunk. The deferred message_delta must carry it.
+    const sse = [
+      'data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"glm-4.6","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}',
+      '',
+      'data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"glm-4.6","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}',
+      '',
+      'data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"glm-4.6","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
+      '',
+      'data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"glm-4.6","choices":[],"usage":{"prompt_tokens":42,"completion_tokens":7,"total_tokens":49}}',
+      '',
+      'data: [DONE]',
+      '',
+    ].join('\n');
+
+    const output = await collectStream(openaiSseToAnthropicSse(makeStream(sse), "glm-4.6"));
+    const events = parseAnthropicEvents(output);
+    const messageDelta = events.find((e) => e.event === "message_delta");
+    expect(messageDelta).toBeDefined();
+    expect(messageDelta!.data.usage.input_tokens).toBe(42);
+    expect(messageDelta!.data.usage.output_tokens).toBe(7);
+  });
+
+  it("subtracts cached tokens from input_tokens in the deferred message_delta", async () => {
+    const sse = [
+      'data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"glm-4.6","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}',
+      '',
+      'data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"glm-4.6","choices":[],"usage":{"prompt_tokens":100,"completion_tokens":5,"total_tokens":105,"prompt_tokens_details":{"cached_tokens":80}}}',
+      '',
+      'data: [DONE]',
+      '',
+    ].join('\n');
+
+    const output = await collectStream(openaiSseToAnthropicSse(makeStream(sse), "glm-4.6"));
+    const events = parseAnthropicEvents(output);
+    const messageDelta = events.find((e) => e.event === "message_delta");
+    expect(messageDelta!.data.usage.input_tokens).toBe(20); // 100 - 80
+    expect(messageDelta!.data.usage.cache_read_input_tokens).toBe(80);
+    expect(messageDelta!.data.usage.output_tokens).toBe(5);
+  });
+
+  it("emits exactly one message_delta even when both finish_reason and [DONE] are present", async () => {
+    const sse = [
+      'data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"glm-4.6","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}',
+      '',
+      'data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"glm-4.6","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
+      '',
+      'data: {"id":"c1","object":"chat.completion.chunk","created":1,"model":"glm-4.6","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":2,"total_tokens":12}}',
+      '',
+      'data: [DONE]',
+      '',
+    ].join('\n');
+
+    const output = await collectStream(openaiSseToAnthropicSse(makeStream(sse), "glm-4.6"));
+    const events = parseAnthropicEvents(output);
+    const deltas = events.filter((e) => e.event === "message_delta");
+    const stops = events.filter((e) => e.event === "message_stop");
+    expect(deltas).toHaveLength(1);
+    expect(stops).toHaveLength(1);
+    expect(deltas[0].data.delta.stop_reason).toBe("end_turn");
+  });
 });

--- a/src/translator/sse-translator.ts
+++ b/src/translator/sse-translator.ts
@@ -3,7 +3,8 @@
  * @see .omo/plans/zcode-proxy.md Task 12
  * @see https://docs.anthropic.com/en/api/messages-streaming
  */
-import type { AnthropicStreamEvent, OpenAIStreamChunk } from "./types.js";
+import type { AnthropicStreamEvent, OpenAIStreamChunk, OpenAIStreamToolCall, OpenAIUsage } from "./types.js";
+import { openaiUsageToAnthropic } from "./anthropic-to-openai.js";
 
 /** Parse a raw SSE chunk string into event type + JSON data. */
 interface ParsedSSE {
@@ -277,6 +278,20 @@ export function openaiSseToAnthropicSse(
   let messageStarted = false;
   let blockIndex = 0;
   let activeBlock: { type: "text" | "thinking"; index: number } | null = null;
+  /** OpenAI tool_call index → Anthropic block state. */
+  const toolBlocks = new Map<number, { index: number; id: string; name: string; started: boolean; pendingArgs: string }>();
+  /** Anthropic block indices of started tool_use blocks, in open order. */
+  const openToolBlockIndices: number[] = [];
+  let outputTokens = 0;
+  /** Latest upstream usage — OpenAI only emits it in the final chunk, so we
+   *  accumulate and emit it once, deferred to end-of-stream. */
+  let latestUsage: OpenAIUsage | undefined;
+  /** Stop reason captured from the finish_reason chunk; held until we can pair
+   *  it with the complete usage before emitting message_delta. */
+  let pendingStopReason: string | null = null;
+  let contentClosed = false;
+  let messageDeltaSent = false;
+  let messageStopped = false;
   const messageId = `msg_${Date.now()}`;
 
   return new ReadableStream({
@@ -297,6 +312,16 @@ export function openaiSseToAnthropicSse(
         activeBlock = null;
       };
 
+      const closeToolBlocks = () => {
+        for (const idx of openToolBlockIndices) {
+          enqueueAnthropicEvent("content_block_stop", {
+            type: "content_block_stop",
+            index: idx,
+          });
+        }
+        openToolBlockIndices.length = 0;
+      };
+
       const ensureActiveBlock = (type: "text" | "thinking"): number => {
         if (activeBlock?.type === type) return activeBlock.index;
         closeActiveBlock();
@@ -310,6 +335,143 @@ export function openaiSseToAnthropicSse(
             : { type: "thinking", thinking: "", signature: "" },
         });
         return index;
+      };
+
+      /**
+       * Route OpenAI streaming tool_call deltas into Anthropic tool_use blocks.
+       * OpenAI identifies each parallel call by `index`; we lazily allocate an
+       * Anthropic block per index, emit `content_block_start` once id+name
+       * arrive, then stream `input_json_delta` for each arguments fragment.
+       * Arguments that arrive before id/name (non-standard ordering from some
+       * compatible upstreams) are buffered into `pendingArgs` and flushed on
+       * start, so the tool input is never silently truncated.
+       */
+      const handleToolCalls = (toolCalls: OpenAIStreamToolCall[]) => {
+        // Tool calls never share a block with text/thinking — close any open prose block first.
+        closeActiveBlock();
+        for (const tc of toolCalls) {
+          const idx = tc.index ?? 0;
+          let state = toolBlocks.get(idx);
+          if (!state) {
+            state = { index: blockIndex++, id: "", name: "", started: false, pendingArgs: "" };
+            toolBlocks.set(idx, state);
+          }
+          if (tc.id) state.id = tc.id;
+          if (tc.function?.name) state.name = tc.function.name;
+
+          if (!state.started && state.id && state.name) {
+            state.started = true;
+            enqueueAnthropicEvent("content_block_start", {
+              type: "content_block_start",
+              index: state.index,
+              content_block: { type: "tool_use", id: state.id, name: state.name, input: {} },
+            });
+            openToolBlockIndices.push(state.index);
+            if (state.pendingArgs.length > 0) {
+              enqueueAnthropicEvent("content_block_delta", {
+                type: "content_block_delta",
+                index: state.index,
+                delta: { type: "input_json_delta", partial_json: state.pendingArgs },
+              });
+              state.pendingArgs = "";
+            }
+          }
+
+          const argsDelta = tc.function?.arguments;
+          if (argsDelta) {
+            if (state.started) {
+              enqueueAnthropicEvent("content_block_delta", {
+                type: "content_block_delta",
+                index: state.index,
+                delta: { type: "input_json_delta", partial_json: argsDelta },
+              });
+            } else {
+              // id/name not yet seen — buffer until the block can open.
+              state.pendingArgs += argsDelta;
+            }
+          }
+        }
+      };
+
+      /**
+       * Force-open any tool blocks that accumulated arguments (or a partial
+       * id/name) but never crossed the id+name threshold before the stream
+       * ended. Uses fallback id/name so the data is surfaced rather than
+       * silently dropped. Mirrors cc-switch's "late tool starts" flush.
+       */
+      const startPendingToolBlocks = () => {
+        const lateStarts: Array<{ index: number; id: string; name: string; args: string }> = [];
+        for (const [openaiIdx, state] of toolBlocks) {
+          if (state.started) continue;
+          if (!state.pendingArgs && !state.id && !state.name) continue;
+          state.started = true;
+          lateStarts.push({
+            index: state.index,
+            id: state.id || `tool_call_${openaiIdx}`,
+            name: state.name || "unknown_tool",
+            args: state.pendingArgs,
+          });
+          state.pendingArgs = "";
+          openToolBlockIndices.push(state.index);
+        }
+        lateStarts.sort((a, b) => a.index - b.index);
+        for (const ls of lateStarts) {
+          enqueueAnthropicEvent("content_block_start", {
+            type: "content_block_start",
+            index: ls.index,
+            content_block: { type: "tool_use", id: ls.id, name: ls.name, input: {} },
+          });
+          if (ls.args.length > 0) {
+            enqueueAnthropicEvent("content_block_delta", {
+              type: "content_block_delta",
+              index: ls.index,
+              delta: { type: "input_json_delta", partial_json: ls.args },
+            });
+          }
+        }
+      };
+
+      /**
+       * Close every open content block (text/thinking/tool_use). Idempotent via
+       * the `contentClosed` flag so it is safe to call at both finish_reason
+       * and end-of-stream. Split from `finalizeStream` so the finish_reason
+       * chunk can close blocks *without* emitting message_delta — the usage
+       * chunk arrives afterwards and must be folded in first.
+       */
+      const closeContent = () => {
+        if (contentClosed) return;
+        contentClosed = true;
+        closeActiveBlock();
+        startPendingToolBlocks();
+        closeToolBlocks();
+      };
+
+      /**
+       * Emit the terminal message_delta + message_stop. The message_delta
+       * carries the full Anthropic usage (input + output + cache) derived from
+       * the latest upstream usage snapshot. This is what lets Anthropic clients
+       * see a non-zero input_tokens despite OpenAI only reporting usage in the
+       * stream's final chunk — the delta is deferred until that chunk lands.
+       */
+      const finalizeStream = () => {
+        closeContent();
+        if (!messageDeltaSent) {
+          messageDeltaSent = true;
+          const usage = openaiUsageToAnthropic(latestUsage);
+          if (!latestUsage) usage.output_tokens = outputTokens;
+          enqueueAnthropicEvent("message_delta", {
+            type: "message_delta",
+            delta: {
+              stop_reason: pendingStopReason ?? "end_turn",
+              stop_sequence: null,
+            },
+            usage,
+          });
+        }
+        if (!messageStopped) {
+          messageStopped = true;
+          enqueueAnthropicEvent("message_stop", { type: "message_stop" });
+        }
       };
 
       try {
@@ -326,8 +488,7 @@ export function openaiSseToAnthropicSse(
             const dataStr = line.slice(6).trim();
 
             if (dataStr === "[DONE]") {
-              closeActiveBlock();
-              enqueueAnthropicEvent("message_stop", { type: "message_stop" });
+              finalizeStream();
               continue;
             }
 
@@ -335,19 +496,35 @@ export function openaiSseToAnthropicSse(
               const chunk = JSON.parse(dataStr) as OpenAIStreamChunk;
               const choice = chunk.choices?.[0];
 
+              // Accumulate usage from every chunk that carries one. OpenAI's
+              // include_usage stream emits it only on the final (often
+              // choices-less) chunk, but compatible upstreams may spread it
+              // across chunks — keep the freshest snapshot.
+              if (chunk.usage) {
+                latestUsage = chunk.usage;
+                outputTokens = chunk.usage.completion_tokens ?? outputTokens;
+              }
+
               if (!messageStarted) {
                 messageStarted = true;
+                // message_start must lead the stream, but the upstream usage
+                // has not arrived yet at this point, so input_tokens starts at
+                // 0 here and is delivered for real via the deferred
+                // message_delta once usage lands. (Anthropic's own streaming
+                // also reports input_tokens up-front; we cannot, given the
+                // upstream timing.)
+                const startUsage = openaiUsageToAnthropic(chunk.usage);
                 enqueueAnthropicEvent("message_start", {
                   type: "message_start",
                   message: {
-                    id: messageId,
+                    id: chunk.id ?? messageId,
                     type: "message",
                     role: "assistant",
                     content: [],
-                    model,
+                    model: chunk.model || model,
                     stop_reason: null,
                     stop_sequence: null,
-                    usage: { input_tokens: 0, output_tokens: 0 },
+                    usage: startUsage,
                   },
                 });
               }
@@ -370,14 +547,16 @@ export function openaiSseToAnthropicSse(
                 });
               }
 
+              if (choice?.delta?.tool_calls?.length) {
+                handleToolCalls(choice.delta.tool_calls);
+              }
+
               if (choice?.finish_reason) {
-                const stopReason = mapFinishReason(choice.finish_reason);
-                closeActiveBlock();
-                enqueueAnthropicEvent("message_delta", {
-                  type: "message_delta",
-                  delta: { stop_reason: stopReason },
-                  usage: { output_tokens: 0 },
-                });
+                // Close blocks now, but hold message_delta until the stream
+                // actually ends so the usage chunk (which follows finish_reason
+                // in include_usage streams) is folded into the final usage.
+                pendingStopReason = mapFinishReason(choice.finish_reason);
+                closeContent();
               }
             } catch {
               // Skip malformed
@@ -385,7 +564,10 @@ export function openaiSseToAnthropicSse(
           }
         }
 
-        closeActiveBlock();
+        // Stream ended — emit the deferred message_delta (with full usage) and
+        // message_stop. Covers both explicit [DONE] already handled above and
+        // streams that terminate without one.
+        finalizeStream();
       } catch (err) {
         errored = true;
         // error()/close() 互斥:errored 流上再 close() 会抛 TypeError,进而触发 Bun 引擎空指针崩溃。

--- a/src/translator/types.ts
+++ b/src/translator/types.ts
@@ -31,17 +31,41 @@ export interface OpenAIMessage {
 }
 
 /** Multi-modal content part (OpenAI format). */
-interface OpenAIContentPart {
+export interface OpenAIContentPart {
   type: "text" | "image_url";
   text?: string;
   image_url?: { url: string; detail?: string };
 }
 
 /** Tool call in an assistant message. */
-interface OpenAIToolCall {
+export interface OpenAIToolCall {
   id: string;
   type: "function";
   function: { name: string; arguments: string };
+}
+
+/** Tool call delta in a streaming chunk (carries `index` to align parallel calls). */
+export interface OpenAIStreamToolCall {
+  index: number;
+  id?: string;
+  type?: "function";
+  function?: { name?: string; arguments?: string };
+}
+
+/**
+ * OpenAI usage block. `prompt_tokens` is *inclusive* of cache hits on most
+ * compatible upstreams, so the Anthropic `input_tokens` (exclusive of cache)
+ * is derived by subtracting the cache buckets — see `openaiUsageToAnthropic`.
+ */
+export interface OpenAIUsage {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+  /** Standard OpenAI cache breakdown. */
+  prompt_tokens_details?: { cached_tokens?: number };
+  /** Anthropic-style direct cache fields (some compatible upstreams emit these). */
+  cache_read_input_tokens?: number;
+  cache_creation_input_tokens?: number;
 }
 
 /** Tool definition in OpenAI format. */
@@ -69,7 +93,7 @@ export interface OpenAIChatRequest {
   logit_bias?: Record<string, number>;
   user?: string;
   tools?: OpenAIToolDefinition[];
-  tool_choice?: "none" | "auto" | "required" | { type: "function"; function: { name: string } };
+  tool_choice?: "none" | "auto" | "required" | { type: "function"; function: { name: string | undefined } };
   response_format?: { type: "text" | "json_object" };
   seed?: number;
   reasoning_effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
@@ -83,11 +107,7 @@ export interface OpenAIChatResponse {
   created: number;
   model: string;
   choices: OpenAIChoice[];
-  usage?: {
-    prompt_tokens: number;
-    completion_tokens: number;
-    total_tokens: number;
-  };
+  usage?: OpenAIUsage;
 }
 
 /** Choice in a non-streaming response. */
@@ -110,6 +130,8 @@ export interface OpenAIStreamChunk {
   created: number;
   model: string;
   choices: OpenAIStreamChoice[];
+  /** Present on the final chunk when `stream_options.include_usage` is set. */
+  usage?: OpenAIUsage;
 }
 
 /** Choice in a streaming chunk. */
@@ -119,7 +141,7 @@ interface OpenAIStreamChoice {
     role?: "assistant";
     content?: string;
     reasoning_content?: string;
-    tool_calls?: Partial<OpenAIToolCall>[];
+    tool_calls?: OpenAIStreamToolCall[];
   };
   finish_reason: "stop" | "length" | "tool_calls" | "content_filter" | null;
 }
@@ -147,7 +169,7 @@ export type AnthropicContentBlock =
   | { type: "text"; text: string }
   | { type: "image"; source: { type: "base64"; media_type: string; data: string } }
   | { type: "tool_use"; id: string; name: string; input: Record<string, unknown> }
-  | { type: "tool_result"; tool_use_id: string; content: string | AnthropicContentBlock[] }
+  | { type: "tool_result"; tool_use_id: string; content: string | AnthropicContentBlock[]; is_error?: boolean }
   | { type: "thinking"; thinking: string; signature?: string };
 
 /** Anthropic message in a request. */
@@ -196,10 +218,15 @@ export interface AnthropicMessagesResponse {
   model: string;
   stop_reason: "end_turn" | "max_tokens" | "stop_sequence" | "tool_use" | null;
   stop_sequence: string | null;
-  usage: {
-    input_tokens: number;
-    output_tokens: number;
-  };
+  usage: AnthropicUsage;
+}
+
+/** Anthropic usage block (cache buckets are optional — only present when non-zero). */
+export interface AnthropicUsage {
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_input_tokens?: number;
+  cache_creation_input_tokens?: number;
 }
 
 // ─────────────────────────────────────────────


### PR DESCRIPTION
Anthropic clients sending tool calls through the OpenAI-compatible upstream were silently losing the tool history, the streaming tool_use events, and every input token. Rework the Anthropic↔OpenAI translators so tool calls, tool results, errors and usage survive the round trip in both directions.

- anthropic→openai request: fan out tool_use→tool_calls and tool_result→ standalone role:"tool" messages (was dropped entirely); map tool_choice (any→required, tool→function selector); preserve image parts, thinking-only reasoning_content, and encode tool_result.is_error as a [tool_error] prefix since OpenAI has no native failure flag
- streaming openai→anthropic: route tool_call deltas by index into separate tool_use blocks, buffer arguments that arrive before id/name, force-open late tool blocks on stream end; defer message_delta to end-of-stream so the real input_tokens (cached token subtraction included) lands instead of 0
- shared openaiUsageToAnthropic: subtract cache buckets from inclusive prompt_tokens, accept both prompt_tokens_details and direct cache fields
- types: add OpenAIUsage / AnthropicUsage / OpenAIStreamToolCall
- .gitignore: ignore .idea/

Fixes #22 