### PR TITLE
fix: 修复 GLM 文本模型不支持图片输入导致的上游 502

### DIFF
--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -16,6 +16,7 @@ import { getProvider } from "../provider/providers.js";
 import { buildUpstreamHeaderPairs, buildUpstreamRequest, type UpstreamHeaderPair } from "./upstream.js";
 import { sendOrderedUpstreamRequest } from "./ordered-transport.js";
 import { transformRequestBody } from "./body-transformer.js";
+import { isKnownTextOnlyModel, isUnsupportedImageError, stripImageUrlsFromOpenAIBodyString } from "./media-sanitizer.js";
 import { type ClientSessionResult } from "./client-session.js";
 import { resolveSessionContext } from "./session-context.js";
 import { detectCaptchaChallenge, getCaptchaToken, invalidateCaptchaToken, RETRY_HEADERS } from "./captcha.js";
@@ -89,6 +90,9 @@ export async function proxyRequest(
   const translateAnthropicToOpenAI = format === "anthropic";
   const translateOpenAIToAnthropic = false;
   const upstreamFormat: Format = "openai";
+  // Flipped to true once the reactive media fallback has run, so the image-strip
+  // retry fires at most once per request.
+  let mediaRetried = false;
   const clientSession = resolveSessionContext({ clientReq, body, upstreamFormat, model: meta.model, config });
   if (debug && clientSession) {
     const shortSession = clientSession.sessionId ? clientSession.sessionId.slice(0, 10) : "-";
@@ -108,9 +112,19 @@ export async function proxyRequest(
     if (debug) debugLine(reqId, `translated Anthropic→OpenAI (bytes=${upstreamBody?.length ?? 0})`);
   }
 
-  const transformedBody = transformRequestBody(upstreamBody, { format: upstreamFormat, userId: startPlan ? undefined : cred.userId, startPlan });
+  let transformedBody = transformRequestBody(upstreamBody, { format: upstreamFormat, userId: startPlan ? undefined : cred.userId, startPlan });
   if (debug && transformedBody !== upstreamBody) {
     debugLine(reqId, `body transformed (upstreamFormat=${upstreamFormat}, startPlan=${startPlan}, bytes=${transformedBody?.length ?? 0})`);
+  }
+  // Preventive media fallback: text-only GLM models reject `image_url` content
+  // blocks with code 1210, so strip them before the first attempt when the
+  // routed model is known to be text-only.
+  if (isKnownTextOnlyModel(meta.model)) {
+    const stripped = stripImageUrlsFromOpenAIBodyString(transformedBody);
+    if (stripped.replaced > 0) {
+      transformedBody = stripped.body;
+      if (debug) debugLine(reqId, `media prevention: stripped ${stripped.replaced} image block(s) for text-only model ${meta.model}`);
+    }
   }
 
   let captchaHeaders: Record<string, string> | undefined;
@@ -183,6 +197,26 @@ export async function proxyRequest(
     }
   }
 
+  // Reactive media fallback (Anthropic clients only): when the upstream rejects
+  // an image block, strip the offending blocks and retry once on the same
+  // upstream. Only translated clients run this — passthrough clients must not
+  // have their response body consumed by error inspection.
+  let lastErrBody = "";
+  if (translateAnthropicToOpenAI) {
+    while (!upstreamResp.ok) {
+      lastErrBody = await upstreamResp.text().catch(() => "");
+      if (mediaRetried || !isUnsupportedImageError(upstreamResp.status, lastErrBody)) break;
+      const stripped = stripImageUrlsFromOpenAIBodyString(transformedBody);
+      if (stripped.replaced === 0) break;
+      mediaRetried = true;
+      if (debug) debugLine(reqId, `media fallback: stripped ${stripped.replaced} image block(s) after upstream ${upstreamResp.status}, retrying`);
+      upstreamHeaderPairs = buildUpstreamHeaderPairs(clientReq, upstreamFormat, cred, config.identity, config.plan, captchaHeaders, clientSession);
+      upstreamReq = buildUpstreamRequest(clientReq, upstreamFormat, provider, cred, stripped.body, config.identity, config.plan, captchaHeaders, clientSession);
+      upstreamResp = await sendUpstreamRequest(upstreamReq, upstreamHeaderPairs, stripped.body, translateOpenAIToAnthropic || translateAnthropicToOpenAI, useOrderedTransport, fetchImpl);
+      if (debug) debugLine(reqId, `← media retry ${upstreamResp.status} ${upstreamResp.statusText}`);
+    }
+  }
+
   const isSSE = upstreamResp.headers.get("content-type")?.includes("text/event-stream") ?? false;
 
   if (translateOpenAIToAnthropic) {
@@ -202,9 +236,10 @@ export async function proxyRequest(
 
   if (translateAnthropicToOpenAI) {
     if (!upstreamResp.ok) {
-      const errBody = await upstreamResp.text().catch(() => "");
+      // lastErrBody was already captured by the media-fallback loop above; the
+      // body stream has been consumed, so reading it again here would yield "".
       printRow(reqId, format, meta, 502, started, headersAt, 0, 0, 0);
-      return errorResponse(502, "translation_failed", `upstream returned ${upstreamResp.status}: ${errBody.slice(0, 200)}`);
+      return errorResponse(502, "translation_failed", `upstream returned ${upstreamResp.status}: ${lastErrBody.slice(0, 200)}`);
     }
     if (isSSE && upstreamResp.body) {
       const translated = openaiSseToAnthropicSse(upstreamResp.body, meta.model);

--- a/src/proxy/media-fallback.test.ts
+++ b/src/proxy/media-fallback.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Handler-level integration tests for the media fallback: prevention (strip
+ * before the first attempt on text-only models) and reactive retry (strip
+ * after the upstream rejects an image block). Mirrors the cc-switch forwarder
+ * wiring in `src-tauri/src/proxy/forwarder.rs`.
+ */
+import { describe, it, expect, mock } from "bun:test";
+import { proxyRequest } from "./handler.js";
+import { AuthManager } from "../auth/manager.js";
+import type { ProxyConfig, ProxyIdentity } from "../config/types.js";
+
+const IDENTITY: ProxyIdentity = {
+  appVersion: "test-1.0.0",
+  sourceTitle: "cli",
+  refererOrigin: "https://zcode.z.ai",
+};
+
+const testConfig: ProxyConfig = {
+  server: { port: 8080, host: "0.0.0.0" },
+  auth: { mode: "apikey", apiKey: "testkey.testsecret" },
+  provider: "zai",
+  plan: "coding-plan",
+  providers: {
+    zai: { anthropicBase: "https://api.z.ai/api/anthropic", openaiBase: "https://api.z.ai/api/coding/paas/v4" },
+    bigmodel: { anthropicBase: "https://open.bigmodel.cn/api/anthropic", openaiBase: "https://open.bigmodel.cn/api/coding/paas/v4" },
+  },
+  defaultModel: "glm-4.6",
+  models: ["glm-4.6"],
+  identity: IDENTITY,
+  clientIdentity: { mode: "observe", ttlSeconds: 900, maxSessions: 1024 },
+  logging: { level: "info" },
+};
+
+function makeAnthropicReq(body: string): Request {
+  return new Request("http://localhost:8080/v1/messages", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body,
+  });
+}
+
+function makeOpenAIReq(body: string): Request {
+  return new Request("http://localhost:8080/v1/chat/completions", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body,
+  });
+}
+
+const OPENAI_OK = JSON.stringify({
+  id: "chatcmpl_1",
+  object: "chat.completion",
+  created: 1,
+  model: "glm-4.6",
+  choices: [{ index: 0, message: { role: "assistant", content: "ok" }, finish_reason: "stop" }],
+  usage: { prompt_tokens: 5, completion_tokens: 1, total_tokens: 6 },
+});
+
+const ERROR_1210 = JSON.stringify({
+  error: { code: "1210", message: "messages.content.type 参数非法，取值范围 ['text']" },
+});
+
+const ANTHROPIC_IMAGE_BODY = {
+  model: "glm-4.6",
+  max_tokens: 1024,
+  messages: [{
+    role: "user",
+    content: [
+      { type: "text", text: "describe this" },
+      { type: "image", source: { type: "base64", media_type: "image/png", data: "abc" } },
+    ],
+  }],
+};
+
+function auth(): AuthManager {
+  return new AuthManager({ mode: "apikey", provider: "zai", apiKey: "testkey.testsecret" });
+}
+
+function hasMarker(content: unknown): boolean {
+  return Array.isArray(content) && content.some(
+    (b) => b && typeof b === "object" && (b as any).type === "text" && (b as any).text === "[Unsupported Image]",
+  );
+}
+
+function hasImageUrl(content: unknown): boolean {
+  return Array.isArray(content) && content.some(
+    (b) => b && typeof b === "object" && (b as any).type === "image_url",
+  );
+}
+
+describe("media fallback — prevention", () => {
+  it("strips the image before the first attempt for a text-only model (anthropic client)", async () => {
+    let captured: any;
+    const fetchMock = mock(async (req: Request): Promise<Response> => {
+      captured = JSON.parse(await req.text());
+      return new Response(OPENAI_OK, { status: 200, headers: { "content-type": "application/json" } });
+    });
+
+    const resp = await proxyRequest(makeAnthropicReq(JSON.stringify(ANTHROPIC_IMAGE_BODY)), "anthropic", {
+      config: testConfig, auth: auth(), fetchImpl: fetchMock as any,
+    });
+
+    expect(resp.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const content = captured.messages[0].content;
+    expect(hasImageUrl(content)).toBe(false);
+    expect(hasMarker(content)).toBe(true);
+  });
+
+  it("keeps the image for a vision model (no preventive strip)", async () => {
+    let captured: any;
+    const fetchMock = mock(async (req: Request): Promise<Response> => {
+      captured = JSON.parse(await req.text());
+      return new Response(OPENAI_OK, { status: 200, headers: { "content-type": "application/json" } });
+    });
+
+    await proxyRequest(makeAnthropicReq(JSON.stringify({ ...ANTHROPIC_IMAGE_BODY, model: "glm-4.6v" })), "anthropic", {
+      config: testConfig, auth: auth(), fetchImpl: fetchMock as any,
+    });
+
+    expect(hasImageUrl(captured.messages[0].content)).toBe(true);
+  });
+
+  it("strips image_url for OpenAI passthrough clients on text-only models", async () => {
+    let captured: any;
+    const fetchMock = mock(async (req: Request): Promise<Response> => {
+      captured = JSON.parse(await req.text());
+      return new Response(OPENAI_OK, { status: 200, headers: { "content-type": "application/json" } });
+    });
+
+    const resp = await proxyRequest(makeOpenAIReq(JSON.stringify({
+      model: "glm-4.6",
+      messages: [{
+        role: "user",
+        content: [
+          { type: "text", text: "look" },
+          { type: "image_url", image_url: { url: "data:image/png;base64,abc" } },
+        ],
+      }],
+    })), "openai", { config: testConfig, auth: auth(), fetchImpl: fetchMock as any });
+
+    expect(resp.status).toBe(200);
+    const content = captured.messages[0].content;
+    expect(hasImageUrl(content)).toBe(false);
+    expect(hasMarker(content)).toBe(true);
+  });
+});
+
+describe("media fallback — reactive retry", () => {
+  it("retries once after a Z.AI 1210 rejection, stripping the image on the retry", async () => {
+    const captured: any[] = [];
+    const fetchMock = mock(async (req: Request): Promise<Response> => {
+      captured.push(JSON.parse(await req.text()));
+      if (captured.length === 1) {
+        return new Response(ERROR_1210, { status: 400, headers: { "content-type": "application/json" } });
+      }
+      return new Response(OPENAI_OK, { status: 200, headers: { "content-type": "application/json" } });
+    });
+
+    // vision model → prevention skips, so the first attempt carries image_url and is rejected
+    const resp = await proxyRequest(
+      makeAnthropicReq(JSON.stringify({ ...ANTHROPIC_IMAGE_BODY, model: "glm-4.6v" })),
+      "anthropic",
+      { config: testConfig, auth: auth(), fetchImpl: fetchMock as any },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(resp.status).toBe(200);
+    expect(hasImageUrl(captured[0].messages[0].content)).toBe(true);
+    expect(hasImageUrl(captured[1].messages[0].content)).toBe(false);
+    expect(hasMarker(captured[1].messages[0].content)).toBe(true);
+  });
+
+  it("does not retry a non-media 400 error", async () => {
+    const fetchMock = mock(async (): Promise<Response> => {
+      return new Response(JSON.stringify({ error: { message: "Invalid API key" } }), {
+        status: 400, headers: { "content-type": "application/json" },
+      });
+    });
+
+    const resp = await proxyRequest(
+      makeAnthropicReq(JSON.stringify({ ...ANTHROPIC_IMAGE_BODY, model: "glm-4.6v" })),
+      "anthropic",
+      { config: testConfig, auth: auth(), fetchImpl: fetchMock as any },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(resp.status).toBe(502);
+    const body = await resp.json();
+    expect(body.error.type).toBe("translation_failed");
+  });
+
+  it("returns 502 when the retry also fails", async () => {
+    const fetchMock = mock(async (): Promise<Response> => {
+      return new Response(ERROR_1210, { status: 400, headers: { "content-type": "application/json" } });
+    });
+
+    const resp = await proxyRequest(
+      makeAnthropicReq(JSON.stringify({ ...ANTHROPIC_IMAGE_BODY, model: "glm-4.6v" })),
+      "anthropic",
+      { config: testConfig, auth: auth(), fetchImpl: fetchMock as any },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(resp.status).toBe(502);
+  });
+});

--- a/src/proxy/media-sanitizer.test.ts
+++ b/src/proxy/media-sanitizer.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Tests for the media sanitizer — mirrors cc-switch's
+ * `src-tauri/src/proxy/media_sanitizer.rs` test cases, adapted to the
+ * OpenAI-format body that zcode-api feeds into this module.
+ */
+import { describe, it, expect } from "bun:test";
+import {
+  UNSUPPORTED_IMAGE_MARKER,
+  openAIBodyContainsImage,
+  replaceOpenAIImageUrlsInPlace,
+  stripImageUrlsFromOpenAIBodyString,
+  modelSupportsImage,
+  isKnownTextOnlyModel,
+  isUnsupportedImageError,
+} from "./media-sanitizer.js";
+
+function imageBlock(): { type: string; image_url: { url: string }; cache_control?: unknown } {
+  return { type: "image_url", image_url: { url: "data:image/png;base64,abc" } };
+}
+
+function bodyWith(messages: unknown): unknown {
+  return { model: "glm-4.6", messages };
+}
+
+describe("replaceOpenAIImageUrlsInPlace", () => {
+  it("replaces a single image_url block with the text marker", () => {
+    const body = bodyWith([
+      { role: "user", content: [{ type: "text", text: "look" }, imageBlock()] },
+    ]);
+
+    const replaced = replaceOpenAIImageUrlsInPlace(body);
+
+    expect(replaced).toBe(1);
+    const content = (body as any).messages[0].content;
+    expect(content[0]).toEqual({ type: "text", text: "look" });
+    expect(content[1]).toEqual({ type: "text", text: UNSUPPORTED_IMAGE_MARKER });
+  });
+
+  it("replaces multiple image blocks across messages", () => {
+    const body = bodyWith([
+      { role: "user", content: [imageBlock(), { type: "text", text: "a" }] },
+      { role: "user", content: [imageBlock()] },
+    ]);
+
+    expect(replaceOpenAIImageUrlsInPlace(body)).toBe(2);
+  });
+
+  it("migrates cache_control onto the replacement text block", () => {
+    const body = bodyWith([
+      {
+        role: "user",
+        content: [{ ...imageBlock(), cache_control: { type: "ephemeral" } }],
+      },
+    ]);
+
+    replaceOpenAIImageUrlsInPlace(body);
+    const block = (body as any).messages[0].content[0];
+    expect(block).toEqual({
+      type: "text",
+      text: UNSUPPORTED_IMAGE_MARKER,
+      cache_control: { type: "ephemeral" },
+    });
+  });
+
+  it("reaches image blocks nested inside a tool_result content array", () => {
+    const body = bodyWith([
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_call_id: "call_1",
+            content: [imageBlock(), { type: "text", text: "ok" }],
+          },
+        ],
+      },
+    ]);
+
+    expect(replaceOpenAIImageUrlsInPlace(body)).toBe(1);
+    const nested = (body as any).messages[0].content[0].content;
+    expect(nested[0]).toEqual({ type: "text", text: UNSUPPORTED_IMAGE_MARKER });
+    expect(nested[1]).toEqual({ type: "text", text: "ok" });
+  });
+
+  it("returns 0 and leaves the body untouched when there is no image block", () => {
+    const body = bodyWith([
+      { role: "user", content: "plain string" },
+      { role: "assistant", content: null },
+    ]);
+
+    expect(replaceOpenAIImageUrlsInPlace(body)).toBe(0);
+  });
+
+  it("is a no-op on bodies without a messages array", () => {
+    expect(replaceOpenAIImageUrlsInPlace({ model: "glm-4.6" })).toBe(0);
+    expect(replaceOpenAIImageUrlsInPlace(null)).toBe(0);
+    expect(replaceOpenAIImageUrlsInPlace(undefined)).toBe(0);
+  });
+});
+
+describe("openAIBodyContainsImage", () => {
+  it("detects an image_url at the top level", () => {
+    expect(openAIBodyContainsImage(bodyWith([
+      { role: "user", content: [imageBlock()] },
+    ]))).toBe(true);
+  });
+
+  it("detects an image nested in tool_result content", () => {
+    expect(openAIBodyContainsImage(bodyWith([
+      {
+        role: "user",
+        content: [{ type: "tool_result", tool_call_id: "c", content: [imageBlock()] }],
+      },
+    ]))).toBe(true);
+  });
+
+  it("returns false for text-only bodies", () => {
+    expect(openAIBodyContainsImage(bodyWith([
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+    ]))).toBe(false);
+    expect(openAIBodyContainsImage(bodyWith([
+      { role: "user", content: "hi" },
+    ]))).toBe(false);
+  });
+});
+
+describe("stripImageUrlsFromOpenAIBodyString", () => {
+  it("parses, strips, and re-serializes", () => {
+    const body = JSON.stringify(bodyWith([
+      { role: "user", content: [imageBlock()] },
+    ]));
+
+    const result = stripImageUrlsFromOpenAIBodyString(body);
+    expect(result.replaced).toBe(1);
+    const reparsed = JSON.parse(result.body!);
+    expect(reparsed.messages[0].content[0]).toEqual({ type: "text", text: UNSUPPORTED_IMAGE_MARKER });
+  });
+
+  it("returns the same string reference when nothing changed", () => {
+    const body = JSON.stringify(bodyWith([{ role: "user", content: "hi" }]));
+    const result = stripImageUrlsFromOpenAIBodyString(body);
+    expect(result.replaced).toBe(0);
+    expect(result.body).toBe(body);
+  });
+
+  it("returns the original body for empty or unparseable input", () => {
+    expect(stripImageUrlsFromOpenAIBodyString(undefined)).toEqual({ body: undefined, replaced: 0 });
+    expect(stripImageUrlsFromOpenAIBodyString("")).toEqual({ body: "", replaced: 0 });
+    expect(stripImageUrlsFromOpenAIBodyString("not json")).toEqual({ body: "not json", replaced: 0 });
+  });
+});
+
+describe("modelSupportsImage / isKnownTextOnlyModel", () => {
+  it("treats trailing-v GLM ids as vision models", () => {
+    expect(modelSupportsImage("glm-4.6v")).toBe(true);
+    expect(modelSupportsImage("glm-5v-turbo")).toBe(true);
+  });
+
+  it("treats non-v GLM ids as text-only", () => {
+    expect(modelSupportsImage("glm-4.6")).toBe(false);
+    expect(modelSupportsImage("glm-5")).toBe(false);
+    expect(modelSupportsImage("glm-5.1")).toBe(false);
+    expect(modelSupportsImage("glm-4.5-air")).toBe(false);
+  });
+
+  it("isKnownTextOnlyModel is the exact complement of modelSupportsImage", () => {
+    expect(isKnownTextOnlyModel("glm-4.6")).toBe(true);
+    expect(isKnownTextOnlyModel("glm-4.6v")).toBe(false);
+    expect(isKnownTextOnlyModel(undefined)).toBe(false);
+  });
+});
+
+describe("isUnsupportedImageError", () => {
+  it("recognises the Z.AI / Bigmodel code-1210 Chinese error verbatim", () => {
+    const errBody = JSON.stringify({
+      error: { code: "1210", message: "messages.content.type 参数非法，取值范围 ['text']" },
+    });
+    expect(isUnsupportedImageError(400, errBody)).toBe(true);
+  });
+
+  it("recognises the English 'unknown variant image_url, expected text' phrasing", () => {
+    const errBody = JSON.stringify({
+      error: {
+        message:
+          "Failed to deserialize the JSON body into the target type: messages[11]: unknown variant `image_url`, expected `text`",
+      },
+    });
+    expect(isUnsupportedImageError(400, errBody)).toBe(true);
+  });
+
+  it("recognises an explicit 'does not support image' message", () => {
+    const errBody = JSON.stringify({ error: { message: "This model does not support image input" } });
+    expect(isUnsupportedImageError(400, errBody)).toBe(true);
+  });
+
+  it("recognises Chinese '不支持...图片' phrasings", () => {
+    const errBody = JSON.stringify({ error: { message: "该模型不支持图片输入" } });
+    expect(isUnsupportedImageError(422, errBody)).toBe(true);
+  });
+
+  it("ignores non-media errors even at 400", () => {
+    expect(isUnsupportedImageError(400, JSON.stringify({ error: { message: "Invalid API key" } }))).toBe(false);
+    expect(isUnsupportedImageError(400, JSON.stringify({ error: { code: "other", message: "rate limited" } }))).toBe(false);
+  });
+
+  it("ignores a 200 response that merely mentions images", () => {
+    expect(isUnsupportedImageError(200, JSON.stringify({ error: { message: "image unsupported" } }))).toBe(false);
+  });
+
+  it("falls back to the raw body when it is not JSON", () => {
+    expect(isUnsupportedImageError(400, "image input is not supported by this model")).toBe(true);
+  });
+});

--- a/src/proxy/media-sanitizer.ts
+++ b/src/proxy/media-sanitizer.ts
@@ -1,0 +1,222 @@
+/**
+ * Media sanitizer — strips image content blocks before forwarding to upstreams
+ * that reject non-text blocks.
+ *
+ * Z.AI / Bigmodel GLM coding-plan models reply with
+ * `{"error":{"code":"1210","message":"messages.content.type 参数非法，取值范围 ['text']"}}`
+ * when a request carries an `image_url` content part, because the text-only
+ * chat endpoint only accepts `text` blocks. Mirrors cc-switch's
+ * `src-tauri/src/proxy/media_sanitizer.rs` two-tier strategy:
+ *
+ *   1. **Prevention** — for known text-only models, replace image blocks with a
+ *      text marker before the request leaves the proxy.
+ *   2. **Reactive fallback** — when the upstream returns an "unsupported image"
+ *      error anyway, unconditionally strip image blocks and retry once.
+ *
+ * Operates on the translated OpenAI-format body: by the time this runs, both
+ * Anthropic clients (whose `image` blocks the translator turns into
+ * `image_url`) and OpenAI clients carry image input as `{type:"image_url"}`.
+ */
+export const UNSUPPORTED_IMAGE_MARKER = "[Unsupported Image]";
+
+/** Status codes that upstreams use to signal "I cannot handle this media". */
+const UNSUPPORTED_MEDIA_STATUSES = new Set([400, 415, 422, 501]);
+
+/**
+ * GLM vision models carry a trailing `v` after the version digit
+ * (e.g. `glm-4.6v`, `glm-5v-turbo`). Everything else in the Z.AI / Bigmodel
+ * catalog is text-only.
+ */
+const VISION_MODEL_PATTERN = /\d+v(?:\b|-)/i;
+
+interface JsonObject {
+  [key: string]: unknown;
+}
+
+function asObject(value: unknown): JsonObject | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as JsonObject;
+}
+
+/**
+ * Whether a parsed OpenAI Chat body carries any `image_url` content blocks.
+ * Descends into nested `content` arrays so images embedded inside tool-result
+ * blocks are also detected.
+ */
+export function openAIBodyContainsImage(parsed: unknown): boolean {
+  const body = asObject(parsed);
+  if (!body) return false;
+  const messages = body.messages;
+  if (!Array.isArray(messages)) return false;
+  return messages.some((message) => contentContainsImage(asObject(message)?.content));
+}
+
+function contentContainsImage(content: unknown): boolean {
+  if (!Array.isArray(content)) return false;
+  return content.some((block) => {
+    const obj = asObject(block);
+    if (!obj) return false;
+    if (obj.type === "image_url") return true;
+    return contentContainsImage(obj.content);
+  });
+}
+
+/**
+ * Replace every `image_url` content block in a parsed OpenAI Chat body with a
+ * text marker. A preserved `cache_control` is migrated onto the replacement so
+ * prompt-cache breakpoints survive the swap. Returns the number of blocks
+ * replaced; the body is mutated in place.
+ */
+export function replaceOpenAIImageUrlsInPlace(parsed: unknown): number {
+  const body = asObject(parsed);
+  if (!body) return 0;
+  const messages = body.messages;
+  if (!Array.isArray(messages)) return 0;
+  let replaced = 0;
+  for (const message of messages) {
+    const obj = asObject(message);
+    if (!obj) continue;
+    replaced += replaceImagesInContent(obj.content);
+  }
+  return replaced;
+}
+
+function replaceImagesInContent(content: unknown): number {
+  if (!Array.isArray(content)) return 0;
+  let replaced = 0;
+  for (const block of content) {
+    const obj = asObject(block);
+    if (!obj) continue;
+    if (obj.type === "image_url") {
+      const preservedCacheControl = obj.cache_control;
+      for (const key of Object.keys(obj)) {
+        if (key !== "cache_control") delete obj[key];
+      }
+      obj.type = "text";
+      obj.text = UNSUPPORTED_IMAGE_MARKER;
+      if (preservedCacheControl !== undefined) obj.cache_control = preservedCacheControl;
+      replaced++;
+      continue;
+    }
+    if (Array.isArray(obj.content)) {
+      replaced += replaceImagesInContent(obj.content);
+    }
+  }
+  return replaced;
+}
+
+/**
+ * Parse an OpenAI Chat body string, strip image blocks, and re-serialize.
+ * Returns `{ body, replaced }`. The original string is returned untouched
+ * (same reference, `replaced: 0`) when the body is empty, unparseable, or
+ * carries no image blocks — so callers can cheaply detect a no-op.
+ */
+export function stripImageUrlsFromOpenAIBodyString(
+  body: string | undefined,
+): { body: string | undefined; replaced: number } {
+  if (body === undefined || body.length === 0) return { body, replaced: 0 };
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return { body, replaced: 0 };
+  }
+  const replaced = replaceOpenAIImageUrlsInPlace(parsed);
+  if (replaced === 0) return { body, replaced: 0 };
+  return { body: JSON.stringify(parsed), replaced };
+}
+
+/**
+ * Whether a model id names a vision-capable GLM variant. Used to decide
+ * preventive stripping — text-only models get their images replaced before the
+ * first attempt so we avoid a wasted round-trip.
+ */
+export function modelSupportsImage(model: string | undefined): boolean {
+  if (!model) return false;
+  return VISION_MODEL_PATTERN.test(model);
+}
+
+/**
+ * Whether a model is known to be text-only. Conservative mirror of cc-switch's
+ * `known_text_only_model`: in the Z.AI / Bigmodel catalog the vision variants
+ * are explicitly tagged with a trailing `v`, so anything that is not tagged is
+ * treated as text-only.
+ */
+export function isKnownTextOnlyModel(model: string | undefined): boolean {
+  if (!model) return false;
+  return !modelSupportsImage(model);
+}
+
+/**
+ * Detect whether an upstream error body is an "unsupported image / non-text
+ * content" rejection. Recognises Z.AI / Bigmodel's `code:1210` Chinese error
+ * as well as the English phrasings other compatible upstreams emit.
+ */
+export function isUnsupportedImageError(status: number, errBody: string): boolean {
+  if (!UNSUPPORTED_MEDIA_STATUSES.has(status)) return false;
+
+  let message = "";
+  let code = "";
+  try {
+    const parsed = JSON.parse(errBody) as unknown;
+    const obj = asObject(parsed);
+    const errObj = asObject(obj?.error) ?? obj;
+    const rawMessage = errObj?.message ?? obj?.message ?? "";
+    message = typeof rawMessage === "string" ? rawMessage : String(rawMessage ?? "");
+    const rawCode = errObj?.code ?? obj?.code;
+    code = typeof rawCode === "string" ? rawCode : "";
+  } catch {
+    message = errBody ?? "";
+  }
+
+  // Z.AI / Bigmodel GLM: code 1210 — content type rejected by text-only model.
+  if (code === "1210") return true;
+
+  const lower = message.toLowerCase();
+
+  // "messages.content.type ... ['text']" / "unknown variant `image_url`, expected `text`"
+  if (/content[._]type/.test(message) && lower.includes("text")) return true;
+  if (lower.includes("image_url") && lower.includes("text")) return true;
+  if (lower.includes("unknown variant") && lower.includes("text")) return true;
+
+  // English phrasings: "image ... unsupported / not supported / text only / ..."
+  const mentionsImage = [
+    "image",
+    "vision",
+    "multimodal",
+    "multi-modal",
+    "modality",
+    "modalities",
+    "media",
+    "attachment",
+  ].some((keyword) => lower.includes(keyword));
+  if (mentionsImage) {
+    const unsupportedHints = [
+      "unsupported",
+      "not supported",
+      "does not support",
+      "doesn't support",
+      "do not support",
+      "don't support",
+      "only supports text",
+      "text only",
+      "text-only",
+      "invalid content type",
+      "invalid message content",
+      "unknown content type",
+      "unrecognized content type",
+      "cannot process",
+      "cannot handle",
+      "can't process",
+      "can't handle",
+      "unable to process",
+    ];
+    if (unsupportedHints.some((hint) => lower.includes(hint))) return true;
+  }
+
+  // Chinese phrasings: "不支持...图片/图像/视觉/image"
+  if (/不支持.{0,8}(图片|图像|视觉|image)/i.test(message)) return true;
+  if (/(图片|图像|视觉).{0,8}不支持/.test(message)) return true;
+
+  return false;
+}


### PR DESCRIPTION
anthropic 客户端携带的 image 块会被翻译成 image_url 发往上游，而
GLM 文本模型（glm-4.6/glm-5 等）的 chat 端点只接受 text 类型 content 块，上游返回 code 1210「messages.content.type 参数非法，取值范围
['text']」，代理将其包装成 502 返回给客户端。

参考 cc-switch 的 media_sanitizer 实现双保险：

- 新增 src/proxy/media-sanitizer.ts：将 image_url 块替换为文本标记 [Unsupported Image]（保留 cache_control，递归处理 tool_result 内嵌 图片），并识别 1210 及各类不支持图片的错误
- handler.ts 接入两道防线：发送前对已知文本模型预先剥离图片，避免 一次多余请求；上游实际报图片错误时再无条件剥离并重试一次
- 新增 media-sanitizer.test.ts 与 media-fallback.test.ts，共 28 个 用例，全部测试 324 pass / 0 fail