### PR TITLE
feat(models): add GLM-4.7-Flash and GLM-5.3-Flash support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist/
 /zcode-proxy-linux-*
 /zcode-proxy-darwin-*
 .idea/
+logs/
 
 # Android build artifacts
 Android-APP/app/build/

--- a/Android-APP/app/src/main/assets/server_bundle/config.example.yaml
+++ b/Android-APP/app/src/main/assets/server_bundle/config.example.yaml
@@ -42,12 +42,14 @@ models:
   - glm-4.6
   - glm-4.6v
   - glm-4.7
+  - glm-4.7-flash
   - glm-5
   - glm-5-turbo
   - glm-5v-turbo
   - glm-5.1
   - glm-5.2
   - glm-5.3
+  - glm-5.3-flash
 
 # Configurable identity headers injected on every upstream request to mimic the
 # ZCode desktop client (User-Agent, X-ZCode-App-Version, X-Title,

--- a/Android-APP/app/src/main/assets/server_bundle/server.cjs
+++ b/Android-APP/app/src/main/assets/server_bundle/server.cjs
@@ -110305,12 +110305,14 @@ models:
   - glm-4.6
   - glm-4.6v
   - glm-4.7
+  - glm-4.7-flash
   - glm-5
   - glm-5-turbo
   - glm-5v-turbo
   - glm-5.1
   - glm-5.2
   - glm-5.3
+  - glm-5.3-flash
 
 # Configurable identity headers injected on every upstream request to mimic the
 # ZCode desktop client (User-Agent, X-ZCode-App-Version, X-Title,
@@ -110868,9 +110870,25 @@ var webui_default = `<!doctype html>\r
       // Known model catalog (used as a fallback when /v1/models is unreachable,\r
       // e.g. before the proxy key has been entered).\r
       var KNOWN_MODELS = [\r
-        "glm-4.5-air", "glm-4.6", "glm-4.6v", "glm-4.7", "glm-5",\r
-        "glm-5-turbo", "glm-5v-turbo", "glm-5.1", "glm-5.2"\r
+        "glm-4.5-air", "glm-4.6", "glm-4.6v", "glm-4.7", "glm-4.7-flash", "glm-5",\r
+        "glm-5-turbo", "glm-5v-turbo", "glm-5.1", "glm-5.2", "glm-5.3", "glm-5.3-flash"\r
       ];\r
+      // Fallback capabilities used before /v1/models is reachable. The live\r
+      // endpoint replaces/augments these entries with server-side metadata.\r
+      var MODEL_CAPABILITIES = {\r
+        "glm-4.5-air": { reasoning: true, input_modalities: ["text"] },\r
+        "glm-4.6": { reasoning: true, input_modalities: ["text"] },\r
+        "glm-4.6v": { reasoning: false, input_modalities: ["text", "image"] },\r
+        "glm-4.7": { reasoning: true, input_modalities: ["text"] },\r
+        "glm-4.7-flash": { reasoning: true, input_modalities: ["text"] },\r
+        "glm-5": { reasoning: true, input_modalities: ["text"] },\r
+        "glm-5-turbo": { reasoning: true, input_modalities: ["text"] },\r
+        "glm-5v-turbo": { reasoning: false, input_modalities: ["text", "image"] },\r
+        "glm-5.1": { reasoning: true, input_modalities: ["text"] },\r
+        "glm-5.2": { reasoning: true, input_modalities: ["text"] },\r
+        "glm-5.3": { reasoning: true, input_modalities: ["text"] },\r
+        "glm-5.3-flash": { reasoning: true, input_modalities: ["text", "image", "video"], thinking_required: true }\r
+      };\r
 \r
       var DEFAULT_SETTINGS = {\r
         apiKey: "",\r
@@ -111165,7 +111183,11 @@ var webui_default = `<!doctype html>\r
             return r.json();\r
           })\r
           .then(function (j) {\r
-            var ids = (j.data || []).map(function (m) { return m.id; });\r
+            var entries = Array.isArray(j.data) ? j.data : [];\r
+            entries.forEach(function (m) {\r
+              if (m && m.id && m.capabilities) MODEL_CAPABILITIES[m.id] = m.capabilities;\r
+            });\r
+            var ids = entries.map(function (m) { return m.id; });\r
             populateModels(ids); setStatus("ok");\r
           })\r
           .catch(function () {\r
@@ -111177,7 +111199,14 @@ var webui_default = `<!doctype html>\r
         statusDot.className = "status-dot" + (s === "ok" ? " ok" : s === "err" ? " err" : "");\r
         statusDot.title = s === "ok" ? "Connected" : s === "err" ? "Request failed (check key / proxy)" : "Set proxy API key in settings";\r
       }\r
-      function isVisionModel(id) { return /v/i.test(id || ""); }\r
+      function getModelCapabilities(id) {\r
+        return MODEL_CAPABILITIES[id] || null;\r
+      }\r
+      function isVisionModel(id) {\r
+        var caps = getModelCapabilities(id);\r
+        if (caps && Array.isArray(caps.input_modalities)) return caps.input_modalities.indexOf("image") >= 0;\r
+        return /v/i.test(id || "");\r
+      }\r
       function syncAttachVisibility() { attachBtn.hidden = !isVisionModel(modelSel.value); }\r
 \r
       // =========================================================\r
@@ -111233,8 +111262,13 @@ var webui_default = `<!doctype html>\r
         return body;\r
       }\r
       function isReasoningModel(id) {\r
-        // reasoning_effort is only honored by GLM-5.2 and above per BigModel docs.\r
-        return /glm-5\\.[2-9]|glm-[6-9]/i.test(id || "");\r
+        var caps = getModelCapabilities(id);\r
+        if (caps && typeof caps.reasoning === "boolean") return caps.reasoning;\r
+        return /glm-4\\.7(?:-flash)?|glm-5\\.[2-9]|glm-[6-9]/i.test(id || "");\r
+      }\r
+      function isThinkingRequired(id) {\r
+        var caps = getModelCapabilities(id);\r
+        return !!(caps && caps.thinking_required === true);\r
       }\r
       // =========================================================\r
       // MCP \u2014 client-managed (browser-direct, optional CORS proxy).\r
@@ -111446,7 +111480,7 @@ var webui_default = `<!doctype html>\r
         if (!text && pendingImages.length === 0) return;\r
         // Block image input for non-vision models with a clear message.\r
         if (pendingImages.length && !isVisionModel(state.settings.model)) {\r
-          toast("This model does not support image input. Select a vision model (name contains 'v', e.g. glm-4.6v).");\r
+          toast("This model does not support image input. Select a model marked as image-capable.");\r
           return;\r
         }\r
         var c = activeConv(); if (!c) { newConv(); c = activeConv(); }\r
@@ -111766,11 +111800,9 @@ var webui_default = `<!doctype html>\r
           pendingImages = []; renderAttachPreview();\r
           toast("Switched to a non-vision model \\u2014 attached images were removed.");\r
         }\r
-        saveState(); syncAttachVisibility(); populateEffort();\r
+        saveState(); syncAttachVisibility(); syncThinkButton();\r
       };\r
-      // GLM-5.2 only has two distinct reasoning-effort levels (low/medium map\r
-      // to high, xhigh maps to max), so expose just high and max. Other models\r
-      // get a disabled placeholder (reasoning_effort is GLM-5.2+ only).\r
+      // Expose the useful high/max effort levels for catalog reasoning models.\r
       function populateEffort() {\r
         var model = modelSel.value;\r
         effortSel.innerHTML = "";\r
@@ -111782,7 +111814,7 @@ var webui_default = `<!doctype html>\r
           });\r
           var cur = state.settings.reasoningEffort;\r
           effortSel.value = (cur === "high") ? "high" : "max";\r
-          effortSel.disabled = !state.settings.thinkingEnabled;\r
+          effortSel.disabled = isThinkingRequired(model) ? false : !state.settings.thinkingEnabled;\r
         } else {\r
           var o = document.createElement("option");\r
           o.value = ""; o.textContent = "n/a";\r
@@ -111791,10 +111823,13 @@ var webui_default = `<!doctype html>\r
         }\r
       }\r
       function syncThinkButton() {\r
+        var required = isThinkingRequired(modelSel.value);\r
+        if (required) state.settings.thinkingEnabled = true;\r
         var on = state.settings.thinkingEnabled;\r
         btnThink.classList.toggle("on", on);\r
         btnThink.textContent = on ? "Think: on" : "Think: off";\r
-        btnThink.title = on ? "Deep thinking on \\u2014 click to turn off" : "Deep thinking off \\u2014 click to turn on";\r
+        btnThink.disabled = required;\r
+        btnThink.title = required ? "Thinking is required for this model" : (on ? "Deep thinking on \\u2014 click to turn off" : "Deep thinking off \\u2014 click to turn on");\r
         // Repopulate so the effort dropdown's disabled state tracks the toggle\r
         // (populateEffort sets disabled = !thinkingEnabled for reasoning models).\r
         populateEffort();\r
@@ -111804,6 +111839,7 @@ var webui_default = `<!doctype html>\r
         saveState();\r
       };\r
       btnThink.onclick = function () {\r
+        if (isThinkingRequired(modelSel.value)) return;\r
         state.settings.thinkingEnabled = !state.settings.thinkingEnabled;\r
         saveState(); syncThinkButton();\r
       };\r
@@ -111819,7 +111855,7 @@ var webui_default = `<!doctype html>\r
         composer.addEventListener(ev, function (e) { e.preventDefault(); composer.style.borderColor = ""; });\r
       });\r
       composer.addEventListener("drop", function (e) {\r
-        if (!isVisionModel(modelSel.value)) { toast("Select a vision model (name contains 'v') to attach images."); return; }\r
+        if (!isVisionModel(modelSel.value)) { toast("Select a model marked as image-capable to attach images."); return; }\r
         if (e.dataTransfer && e.dataTransfer.files) readImages(e.dataTransfer.files);\r
       });\r
 \r
@@ -113302,15 +113338,34 @@ var import_node_zlib = require("node:zlib");
 var MODELS = [
   { id: "glm-4.5-air", name: "GLM 4.5 Air", contextWindow: 2e5, maxOutputTokens: 128e3, reasoning: true },
   { id: "glm-4.6", name: "GLM 4.6", contextWindow: 2e5, maxOutputTokens: 128e3, reasoning: true },
-  { id: "glm-4.6v", name: "GLM 4.6V", contextWindow: 2e5, maxOutputTokens: 128e3 },
+  { id: "glm-4.6v", name: "GLM 4.6V", contextWindow: 2e5, maxOutputTokens: 128e3, inputModalities: ["text", "image"] },
   { id: "glm-4.7", name: "GLM 4.7", contextWindow: 2e5, maxOutputTokens: 128e3, reasoning: true },
+  { id: "glm-4.7-flash", name: "GLM 4.7 Flash", contextWindow: 2e5, maxOutputTokens: 128e3, reasoning: true },
   { id: "glm-5", name: "GLM 5", contextWindow: 2e5, maxOutputTokens: 128e3, reasoning: true },
   { id: "glm-5-turbo", name: "GLM 5 Turbo", contextWindow: 2e5, maxOutputTokens: 128e3, reasoning: true },
-  { id: "glm-5v-turbo", name: "GLM 5V Turbo", contextWindow: 2e5, maxOutputTokens: 128e3 },
+  { id: "glm-5v-turbo", name: "GLM 5V Turbo", contextWindow: 2e5, maxOutputTokens: 128e3, inputModalities: ["text", "image"] },
   { id: "glm-5.1", name: "GLM 5.1", contextWindow: 2e5, maxOutputTokens: 128e3, reasoning: true },
   { id: "glm-5.2", name: "GLM 5.2", contextWindow: 1e6, maxOutputTokens: 128e3, reasoning: true },
-  { id: "glm-5.3", name: "GLM 5.3", contextWindow: 1e6, maxOutputTokens: 128e3, reasoning: true }
+  { id: "glm-5.3", name: "GLM 5.3", contextWindow: 1e6, maxOutputTokens: 128e3, reasoning: true },
+  {
+    id: "glm-5.3-flash",
+    name: "GLM 5.3 Flash",
+    contextWindow: 1e6,
+    maxOutputTokens: 131072,
+    reasoning: true,
+    inputModalities: ["text", "image", "video"],
+    thinkingRequired: true
+  }
 ];
+function getModel(id2) {
+  return MODELS.find((model) => model.id === id2);
+}
+function isReasoningModel(id2) {
+  return getModel(id2)?.reasoning === true;
+}
+function isThinkingRequired(id2) {
+  return getModel(id2)?.thinkingRequired === true;
+}
 
 // src/translator/openai-to-anthropic.ts
 var DEFAULT_MAX_TOKENS = 4096;
@@ -113342,6 +113397,13 @@ function translateRequestOpenAIToAnthropic(req) {
 }
 function translateThinking(req) {
   const explicit = req.thinking;
+  if (isThinkingRequired(req.model)) {
+    const budget = explicit && typeof explicit === "object" ? explicit.budget_tokens ?? explicit.budgetTokens : void 0;
+    return {
+      type: "enabled",
+      ...typeof budget === "number" && Number.isFinite(budget) && budget > 0 ? { budget_tokens: Math.floor(budget) } : {}
+    };
+  }
   if (explicit && typeof explicit === "object") {
     if (explicit.type === "disabled") return { type: "disabled" };
     if (explicit.type === "enabled" || explicit.type === "adaptive") {
@@ -113356,9 +113418,6 @@ function translateThinking(req) {
   if (req.reasoning_effort === "none") return { type: "disabled" };
   if (isReasoningModel(req.model)) return { type: "enabled" };
   return void 0;
-}
-function isReasoningModel(model) {
-  return MODELS.some((m) => m.id === model && m.reasoning === true);
 }
 function translateToolChoice(choice) {
   if (choice === "auto") return { type: "auto" };
@@ -113430,20 +113489,7 @@ function toolResultContent(msg) {
     const joined = msg.content.map((c) => c.text ?? "").join("");
     return joined;
   }
-  return msg.content.map((c) => {
-    if (c.type === "text") return { type: "text", text: c.text ?? "" };
-    if (c.type === "image_url" && c.image_url) {
-      const parsed = parseDataUrl(c.image_url.url);
-      if (parsed) {
-        return {
-          type: "image",
-          source: { type: "base64", media_type: parsed.mediaType, data: parsed.data }
-        };
-      }
-      return { type: "text", text: c.image_url.url };
-    }
-    return { type: "text", text: "" };
-  });
+  return msg.content.map(translateOpenAIContentPart);
 }
 function parseDataUrl(url2) {
   const m = /^data:([^;]+);base64,(.*)$/s.exec(url2);
@@ -113497,13 +113543,23 @@ function extractText(msg) {
 function translateContentOpenAIToAnthropic(msg) {
   if (typeof msg.content === "string") return msg.content;
   if (msg.content === null) return "";
-  if (Array.isArray(msg.content)) {
-    return msg.content.map((c) => {
-      if (c.type === "text") return { type: "text", text: c.text ?? "" };
-      return { type: "text", text: "" };
-    });
-  }
+  if (Array.isArray(msg.content)) return msg.content.map(translateOpenAIContentPart);
   return "";
+}
+function translateOpenAIContentPart(part) {
+  if (part.type === "text") return { type: "text", text: part.text ?? "" };
+  const url2 = part.image_url?.url ?? "";
+  const parsed = parseDataUrl(url2);
+  if (parsed) {
+    return {
+      type: "image",
+      source: { type: "base64", media_type: parsed.mediaType, data: parsed.data }
+    };
+  }
+  if (/^https?:\/\//i.test(url2)) {
+    return { type: "image", source: { type: "url", url: url2 } };
+  }
+  return { type: "text", text: url2 };
 }
 function translateToolOpenAIToAnthropic(tool) {
   return {
@@ -113635,6 +113691,11 @@ function translateMessageAnthropicToOpenAI(m) {
           contentParts.push({
             type: "image_url",
             image_url: { url: `data:${block.source.media_type};base64,${block.source.data}` }
+          });
+        } else if (block.source.type === "url") {
+          contentParts.push({
+            type: "image_url",
+            image_url: { url: block.source.url }
           });
         }
         break;
@@ -114923,7 +114984,14 @@ function handleListModels() {
     data: MODELS.map((m) => ({
       id: m.id,
       object: "model",
-      owned_by: "zcode-proxy"
+      owned_by: "zcode-proxy",
+      capabilities: {
+        context_window: m.contextWindow,
+        ...m.maxOutputTokens !== void 0 ? { max_output_tokens: m.maxOutputTokens } : {},
+        reasoning: m.reasoning === true,
+        input_modalities: [...m.inputModalities ?? ["text"]],
+        ...m.thinkingRequired ? { thinking_required: true } : {}
+      }
     }))
   };
   return new Response(JSON.stringify(list), {

--- a/Android-APP/app/src/main/assets/server_bundle/webui.txt
+++ b/Android-APP/app/src/main/assets/server_bundle/webui.txt
@@ -441,9 +441,25 @@
       // Known model catalog (used as a fallback when /v1/models is unreachable,
       // e.g. before the proxy key has been entered).
       var KNOWN_MODELS = [
-        "glm-4.5-air", "glm-4.6", "glm-4.6v", "glm-4.7", "glm-5",
-        "glm-5-turbo", "glm-5v-turbo", "glm-5.1", "glm-5.2"
+        "glm-4.5-air", "glm-4.6", "glm-4.6v", "glm-4.7", "glm-4.7-flash", "glm-5",
+        "glm-5-turbo", "glm-5v-turbo", "glm-5.1", "glm-5.2", "glm-5.3", "glm-5.3-flash"
       ];
+      // Fallback capabilities used before /v1/models is reachable. The live
+      // endpoint replaces/augments these entries with server-side metadata.
+      var MODEL_CAPABILITIES = {
+        "glm-4.5-air": { reasoning: true, input_modalities: ["text"] },
+        "glm-4.6": { reasoning: true, input_modalities: ["text"] },
+        "glm-4.6v": { reasoning: false, input_modalities: ["text", "image"] },
+        "glm-4.7": { reasoning: true, input_modalities: ["text"] },
+        "glm-4.7-flash": { reasoning: true, input_modalities: ["text"] },
+        "glm-5": { reasoning: true, input_modalities: ["text"] },
+        "glm-5-turbo": { reasoning: true, input_modalities: ["text"] },
+        "glm-5v-turbo": { reasoning: false, input_modalities: ["text", "image"] },
+        "glm-5.1": { reasoning: true, input_modalities: ["text"] },
+        "glm-5.2": { reasoning: true, input_modalities: ["text"] },
+        "glm-5.3": { reasoning: true, input_modalities: ["text"] },
+        "glm-5.3-flash": { reasoning: true, input_modalities: ["text", "image", "video"], thinking_required: true }
+      };
 
       var DEFAULT_SETTINGS = {
         apiKey: "",
@@ -738,7 +754,11 @@
             return r.json();
           })
           .then(function (j) {
-            var ids = (j.data || []).map(function (m) { return m.id; });
+            var entries = Array.isArray(j.data) ? j.data : [];
+            entries.forEach(function (m) {
+              if (m && m.id && m.capabilities) MODEL_CAPABILITIES[m.id] = m.capabilities;
+            });
+            var ids = entries.map(function (m) { return m.id; });
             populateModels(ids); setStatus("ok");
           })
           .catch(function () {
@@ -750,7 +770,14 @@
         statusDot.className = "status-dot" + (s === "ok" ? " ok" : s === "err" ? " err" : "");
         statusDot.title = s === "ok" ? "Connected" : s === "err" ? "Request failed (check key / proxy)" : "Set proxy API key in settings";
       }
-      function isVisionModel(id) { return /v/i.test(id || ""); }
+      function getModelCapabilities(id) {
+        return MODEL_CAPABILITIES[id] || null;
+      }
+      function isVisionModel(id) {
+        var caps = getModelCapabilities(id);
+        if (caps && Array.isArray(caps.input_modalities)) return caps.input_modalities.indexOf("image") >= 0;
+        return /v/i.test(id || "");
+      }
       function syncAttachVisibility() { attachBtn.hidden = !isVisionModel(modelSel.value); }
 
       // =========================================================
@@ -806,8 +833,13 @@
         return body;
       }
       function isReasoningModel(id) {
-        // reasoning_effort is only honored by GLM-5.2 and above per BigModel docs.
-        return /glm-5\.[2-9]|glm-[6-9]/i.test(id || "");
+        var caps = getModelCapabilities(id);
+        if (caps && typeof caps.reasoning === "boolean") return caps.reasoning;
+        return /glm-4\.7(?:-flash)?|glm-5\.[2-9]|glm-[6-9]/i.test(id || "");
+      }
+      function isThinkingRequired(id) {
+        var caps = getModelCapabilities(id);
+        return !!(caps && caps.thinking_required === true);
       }
       // =========================================================
       // MCP — client-managed (browser-direct, optional CORS proxy).
@@ -1019,7 +1051,7 @@
         if (!text && pendingImages.length === 0) return;
         // Block image input for non-vision models with a clear message.
         if (pendingImages.length && !isVisionModel(state.settings.model)) {
-          toast("This model does not support image input. Select a vision model (name contains 'v', e.g. glm-4.6v).");
+          toast("This model does not support image input. Select a model marked as image-capable.");
           return;
         }
         var c = activeConv(); if (!c) { newConv(); c = activeConv(); }
@@ -1339,11 +1371,9 @@
           pendingImages = []; renderAttachPreview();
           toast("Switched to a non-vision model \u2014 attached images were removed.");
         }
-        saveState(); syncAttachVisibility(); populateEffort();
+        saveState(); syncAttachVisibility(); syncThinkButton();
       };
-      // GLM-5.2 only has two distinct reasoning-effort levels (low/medium map
-      // to high, xhigh maps to max), so expose just high and max. Other models
-      // get a disabled placeholder (reasoning_effort is GLM-5.2+ only).
+      // Expose the useful high/max effort levels for catalog reasoning models.
       function populateEffort() {
         var model = modelSel.value;
         effortSel.innerHTML = "";
@@ -1355,7 +1385,7 @@
           });
           var cur = state.settings.reasoningEffort;
           effortSel.value = (cur === "high") ? "high" : "max";
-          effortSel.disabled = !state.settings.thinkingEnabled;
+          effortSel.disabled = isThinkingRequired(model) ? false : !state.settings.thinkingEnabled;
         } else {
           var o = document.createElement("option");
           o.value = ""; o.textContent = "n/a";
@@ -1364,10 +1394,13 @@
         }
       }
       function syncThinkButton() {
+        var required = isThinkingRequired(modelSel.value);
+        if (required) state.settings.thinkingEnabled = true;
         var on = state.settings.thinkingEnabled;
         btnThink.classList.toggle("on", on);
         btnThink.textContent = on ? "Think: on" : "Think: off";
-        btnThink.title = on ? "Deep thinking on \u2014 click to turn off" : "Deep thinking off \u2014 click to turn on";
+        btnThink.disabled = required;
+        btnThink.title = required ? "Thinking is required for this model" : (on ? "Deep thinking on \u2014 click to turn off" : "Deep thinking off \u2014 click to turn on");
         // Repopulate so the effort dropdown's disabled state tracks the toggle
         // (populateEffort sets disabled = !thinkingEnabled for reasoning models).
         populateEffort();
@@ -1377,6 +1410,7 @@
         saveState();
       };
       btnThink.onclick = function () {
+        if (isThinkingRequired(modelSel.value)) return;
         state.settings.thinkingEnabled = !state.settings.thinkingEnabled;
         saveState(); syncThinkButton();
       };
@@ -1392,7 +1426,7 @@
         composer.addEventListener(ev, function (e) { e.preventDefault(); composer.style.borderColor = ""; });
       });
       composer.addEventListener("drop", function (e) {
-        if (!isVisionModel(modelSel.value)) { toast("Select a vision model (name contains 'v') to attach images."); return; }
+        if (!isVisionModel(modelSel.value)) { toast("Select a model marked as image-capable to attach images."); return; }
         if (e.dataTransfer && e.dataTransfer.files) readImages(e.dataTransfer.files);
       });
 

--- a/README.md
+++ b/README.md
@@ -176,8 +176,8 @@ and present the key input); it then sends the key on its own `/v1/*` calls.
 
 Features: streaming responses (SSE), model picker (auto-populated from
 `/v1/models`), editable system prompt, temperature / top-p / max-tokens /
-`do_sample`, deep-thinking toggle with `reasoning_effort` (GLM-5.2+), image
-upload (auto-enabled for models whose id contains `v`), MCP HTTP servers,
+`do_sample`, deep-thinking toggle with `reasoning_effort` (reasoning models), image
+upload (enabled from model capability metadata), MCP HTTP servers,
 markdown + code-highlight rendering, light/dark theme, and per-browser
 multi-session autosave (localStorage). Open Settings (⚙) to configure.
 
@@ -331,12 +331,14 @@ The proxy lists these models on `GET /v1/models` (pinned to the GLM coding-plan 
 | `glm-4.6` | 200K | 128K |
 | `glm-4.6v` | 200K | 128K |
 | `glm-4.7` | 200K | 128K |
+| `glm-4.7-flash` | 200K | 128K |
 | `glm-5` | 200K | 128K |
 | `glm-5-turbo` | 200K | 128K |
 | `glm-5v-turbo` | 200K | 128K |
 | `glm-5.1` | 200K | 128K |
 | `glm-5.2` | 1M | 128K |
 | `glm-5.3` | 1M | 128K |
+| `glm-5.3-flash` | 1M | 128K |
 
 Requests for models not in this list are still forwarded upstream — the listing is informational, not a gate.
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -42,12 +42,14 @@ models:
   - glm-4.6
   - glm-4.6v
   - glm-4.7
+  - glm-4.7-flash
   - glm-5
   - glm-5-turbo
   - glm-5v-turbo
   - glm-5.1
   - glm-5.2
   - glm-5.3
+  - glm-5.3-flash
 
 # Configurable identity headers injected on every upstream request to mimic the
 # ZCode desktop client (User-Agent, X-ZCode-App-Version, X-Title,

--- a/src/config/template.ts
+++ b/src/config/template.ts
@@ -51,12 +51,14 @@ models:
   - glm-4.6
   - glm-4.6v
   - glm-4.7
+  - glm-4.7-flash
   - glm-5
   - glm-5-turbo
   - glm-5v-turbo
   - glm-5.1
   - glm-5.2
   - glm-5.3
+  - glm-5.3-flash
 
 # Configurable identity headers injected on every upstream request to mimic the
 # ZCode desktop client (User-Agent, X-ZCode-App-Version, X-Title,

--- a/src/provider/models.ts
+++ b/src/provider/models.ts
@@ -14,12 +14,42 @@ import type { ModelDef } from "./types.js";
 export const MODELS: ModelDef[] = [
   { id: "glm-4.5-air", name: "GLM 4.5 Air", contextWindow: 200_000, maxOutputTokens: 128_000, reasoning: true },
   { id: "glm-4.6", name: "GLM 4.6", contextWindow: 200_000, maxOutputTokens: 128_000, reasoning: true },
-  { id: "glm-4.6v", name: "GLM 4.6V", contextWindow: 200_000, maxOutputTokens: 128_000 },
+  { id: "glm-4.6v", name: "GLM 4.6V", contextWindow: 200_000, maxOutputTokens: 128_000, inputModalities: ["text", "image"] },
   { id: "glm-4.7", name: "GLM 4.7", contextWindow: 200_000, maxOutputTokens: 128_000, reasoning: true },
+  { id: "glm-4.7-flash", name: "GLM 4.7 Flash", contextWindow: 200_000, maxOutputTokens: 128_000, reasoning: true },
   { id: "glm-5", name: "GLM 5", contextWindow: 200_000, maxOutputTokens: 128_000, reasoning: true },
   { id: "glm-5-turbo", name: "GLM 5 Turbo", contextWindow: 200_000, maxOutputTokens: 128_000, reasoning: true },
-  { id: "glm-5v-turbo", name: "GLM 5V Turbo", contextWindow: 200_000, maxOutputTokens: 128_000 },
+  { id: "glm-5v-turbo", name: "GLM 5V Turbo", contextWindow: 200_000, maxOutputTokens: 128_000, inputModalities: ["text", "image"] },
   { id: "glm-5.1", name: "GLM 5.1", contextWindow: 200_000, maxOutputTokens: 128_000, reasoning: true },
   { id: "glm-5.2", name: "GLM 5.2", contextWindow: 1_000_000, maxOutputTokens: 128_000, reasoning: true },
   { id: "glm-5.3", name: "GLM 5.3", contextWindow: 1_000_000, maxOutputTokens: 128_000, reasoning: true },
+  {
+    id: "glm-5.3-flash",
+    name: "GLM 5.3 Flash",
+    contextWindow: 1_000_000,
+    maxOutputTokens: 131_072,
+    reasoning: true,
+    inputModalities: ["text", "image", "video"],
+    thinkingRequired: true,
+  },
 ];
+
+/** Look up a catalog entry by its exact upstream model id. */
+export function getModel(id: string): ModelDef | undefined {
+  return MODELS.find((model) => model.id === id);
+}
+
+/** Whether a catalog model supports reasoning/thinking. */
+export function isReasoningModel(id: string): boolean {
+  return getModel(id)?.reasoning === true;
+}
+
+/** Whether a catalog model requires thinking to stay enabled. */
+export function isThinkingRequired(id: string): boolean {
+  return getModel(id)?.thinkingRequired === true;
+}
+
+/** Whether a catalog model accepts image input. */
+export function supportsImageInput(id: string): boolean {
+  return getModel(id)?.inputModalities?.includes("image") === true;
+}

--- a/src/provider/providers.test.ts
+++ b/src/provider/providers.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, it, expect } from "bun:test";
 import { getProvider, ZAI_PROVIDER, BIGMODEL_PROVIDER } from "./providers.js";
-import { MODELS } from "./models.js";
+import { getModel, isReasoningModel, isThinkingRequired, MODELS, supportsImageInput } from "./models.js";
 
 describe("providers", () => {
   it("getProvider returns Z.AI definition", () => {
@@ -37,12 +37,12 @@ describe("providers", () => {
 });
 
 describe("models", () => {
-  it("MODELS contains exactly the 10 pinned coding-plan models", () => {
-    expect(MODELS).toHaveLength(10);
+  it("MODELS contains exactly the 12 pinned coding-plan models", () => {
+    expect(MODELS).toHaveLength(12);
     const ids = MODELS.map((m) => m.id);
     expect(ids).toEqual([
-      "glm-4.5-air", "glm-4.6", "glm-4.6v", "glm-4.7",
-      "glm-5", "glm-5-turbo", "glm-5v-turbo", "glm-5.1", "glm-5.2", "glm-5.3",
+      "glm-4.5-air", "glm-4.6", "glm-4.6v", "glm-4.7", "glm-4.7-flash",
+      "glm-5", "glm-5-turbo", "glm-5v-turbo", "glm-5.1", "glm-5.2", "glm-5.3", "glm-5.3-flash",
     ]);
   });
 
@@ -51,24 +51,47 @@ describe("models", () => {
       expect(typeof m.id).toBe("string");
       expect(m.id.length).toBeGreaterThan(0);
       expect(m.contextWindow).toBeGreaterThan(0);
-      expect(m.maxOutputTokens).toBe(128_000);
+      expect(m.maxOutputTokens).toBe(m.id === "glm-5.3-flash" ? 131_072 : 128_000);
     }
   });
 
-  it("all models except glm-5.2/glm-5.3 have 200k context", () => {
+  it("all models except the 1M-context models have 200k context", () => {
     for (const m of MODELS) {
-      if (m.id === "glm-5.2" || m.id === "glm-5.3") continue;
+      if (m.id === "glm-5.2" || m.id === "glm-5.3" || m.id === "glm-5.3-flash") continue;
       expect(m.contextWindow).toBe(200_000);
     }
   });
 
-  it("glm-5.2 and glm-5.3 have 1M context", () => {
+  it("GLM-5.2, GLM-5.3, and GLM-5.3-Flash have 1M context", () => {
     const glm52 = MODELS.find((m) => m.id === "glm-5.2");
     expect(glm52).toBeDefined();
     expect(glm52!.contextWindow).toBe(1_000_000);
     const glm53 = MODELS.find((m) => m.id === "glm-5.3");
     expect(glm53).toBeDefined();
     expect(glm53!.contextWindow).toBe(1_000_000);
+    const glm53Flash = MODELS.find((m) => m.id === "glm-5.3-flash");
+    expect(glm53Flash).toBeDefined();
+    expect(glm53Flash!.contextWindow).toBe(1_000_000);
+  });
+
+  it("records reasoning and multimodal capabilities for the new models", () => {
+    expect(getModel("glm-4.7-flash")).toMatchObject({
+      reasoning: true,
+      contextWindow: 200_000,
+      maxOutputTokens: 128_000,
+    });
+    expect(isReasoningModel("glm-4.7-flash")).toBe(true);
+    expect(supportsImageInput("glm-4.7-flash")).toBe(false);
+
+    expect(getModel("glm-5.3-flash")).toMatchObject({
+      reasoning: true,
+      contextWindow: 1_000_000,
+      maxOutputTokens: 131_072,
+      inputModalities: ["text", "image", "video"],
+      thinkingRequired: true,
+    });
+    expect(supportsImageInput("glm-5.3-flash")).toBe(true);
+    expect(isThinkingRequired("glm-5.3-flash")).toBe(true);
   });
 
   it("includes key GLM models", () => {
@@ -76,6 +99,8 @@ describe("models", () => {
     expect(ids).toContain("glm-4.6");
     expect(ids).toContain("glm-5.2");
     expect(ids).toContain("glm-5.3");
+    expect(ids).toContain("glm-4.7-flash");
+    expect(ids).toContain("glm-5.3-flash");
     expect(ids).toContain("glm-5v-turbo");
   });
 });

--- a/src/provider/types.ts
+++ b/src/provider/types.ts
@@ -18,6 +18,9 @@ export interface ProviderDef {
   bizHost: string;
 }
 
+/** Input modalities advertised by a model. */
+export type ModelInputModality = "text" | "image" | "video";
+
 /** Model definition derived from the catalog. */
 export interface ModelDef {
   id: string;
@@ -26,4 +29,8 @@ export interface ModelDef {
   maxOutputTokens?: number;
   /** Whether the model supports reasoning/thinking mode. */
   reasoning?: boolean;
+  /** Input modalities accepted by the model. Omitted means text-only. */
+  inputModalities?: readonly ModelInputModality[];
+  /** Whether the upstream requires thinking to be enabled for this model. */
+  thinkingRequired?: boolean;
 }

--- a/src/server/routes-openai.ts
+++ b/src/server/routes-openai.ts
@@ -22,6 +22,13 @@ export function handleListModels(): Response {
       id: m.id,
       object: "model" as const,
       owned_by: "zcode-proxy",
+      capabilities: {
+        context_window: m.contextWindow,
+        ...(m.maxOutputTokens !== undefined ? { max_output_tokens: m.maxOutputTokens } : {}),
+        reasoning: m.reasoning === true,
+        input_modalities: [...(m.inputModalities ?? ["text"])] as Array<"text" | "image" | "video">,
+        ...(m.thinkingRequired ? { thinking_required: true } : {}),
+      },
     })),
   };
   return new Response(JSON.stringify(list), {

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -82,6 +82,17 @@ describe("server routing", () => {
     expect(body.object).toBe("list");
     expect(body.data.length).toBeGreaterThan(0);
     expect(body.data[0].object).toBe("model");
+    const ids = body.data.map((model: { id: string }) => model.id);
+    expect(ids).toContain("glm-4.7-flash");
+    expect(ids).toContain("glm-5.3-flash");
+    const glm53Flash = body.data.find((model: { id: string }) => model.id === "glm-5.3-flash");
+    expect(glm53Flash.capabilities).toMatchObject({
+      context_window: 1_000_000,
+      max_output_tokens: 131_072,
+      reasoning: true,
+      input_modalities: ["text", "image", "video"],
+      thinking_required: true,
+    });
   });
 
   it("POST /v1/chat/completions forwards to upstream", async () => {
@@ -240,6 +251,10 @@ describe("web UI", () => {
     expect(resp.headers.get("content-type")).toContain("text/html");
     const body = await resp.text();
     expect(body).toContain("<!doctype html>");
+    expect(body).toContain("glm-4.7-flash");
+    expect(body).toContain("glm-5.3-flash");
+    expect(body).toContain("MODEL_CAPABILITIES");
+    expect(body).toContain("thinking_required");
   });
 
   it("non-GET /webui is not served as the SPA", async () => {

--- a/src/server/webui.txt
+++ b/src/server/webui.txt
@@ -441,9 +441,25 @@
       // Known model catalog (used as a fallback when /v1/models is unreachable,
       // e.g. before the proxy key has been entered).
       var KNOWN_MODELS = [
-        "glm-4.5-air", "glm-4.6", "glm-4.6v", "glm-4.7", "glm-5",
-        "glm-5-turbo", "glm-5v-turbo", "glm-5.1", "glm-5.2"
+        "glm-4.5-air", "glm-4.6", "glm-4.6v", "glm-4.7", "glm-4.7-flash", "glm-5",
+        "glm-5-turbo", "glm-5v-turbo", "glm-5.1", "glm-5.2", "glm-5.3", "glm-5.3-flash"
       ];
+      // Fallback capabilities used before /v1/models is reachable. The live
+      // endpoint replaces/augments these entries with server-side metadata.
+      var MODEL_CAPABILITIES = {
+        "glm-4.5-air": { reasoning: true, input_modalities: ["text"] },
+        "glm-4.6": { reasoning: true, input_modalities: ["text"] },
+        "glm-4.6v": { reasoning: false, input_modalities: ["text", "image"] },
+        "glm-4.7": { reasoning: true, input_modalities: ["text"] },
+        "glm-4.7-flash": { reasoning: true, input_modalities: ["text"] },
+        "glm-5": { reasoning: true, input_modalities: ["text"] },
+        "glm-5-turbo": { reasoning: true, input_modalities: ["text"] },
+        "glm-5v-turbo": { reasoning: false, input_modalities: ["text", "image"] },
+        "glm-5.1": { reasoning: true, input_modalities: ["text"] },
+        "glm-5.2": { reasoning: true, input_modalities: ["text"] },
+        "glm-5.3": { reasoning: true, input_modalities: ["text"] },
+        "glm-5.3-flash": { reasoning: true, input_modalities: ["text", "image", "video"], thinking_required: true }
+      };
 
       var DEFAULT_SETTINGS = {
         apiKey: "",
@@ -738,7 +754,11 @@
             return r.json();
           })
           .then(function (j) {
-            var ids = (j.data || []).map(function (m) { return m.id; });
+            var entries = Array.isArray(j.data) ? j.data : [];
+            entries.forEach(function (m) {
+              if (m && m.id && m.capabilities) MODEL_CAPABILITIES[m.id] = m.capabilities;
+            });
+            var ids = entries.map(function (m) { return m.id; });
             populateModels(ids); setStatus("ok");
           })
           .catch(function () {
@@ -750,7 +770,14 @@
         statusDot.className = "status-dot" + (s === "ok" ? " ok" : s === "err" ? " err" : "");
         statusDot.title = s === "ok" ? "Connected" : s === "err" ? "Request failed (check key / proxy)" : "Set proxy API key in settings";
       }
-      function isVisionModel(id) { return /v/i.test(id || ""); }
+      function getModelCapabilities(id) {
+        return MODEL_CAPABILITIES[id] || null;
+      }
+      function isVisionModel(id) {
+        var caps = getModelCapabilities(id);
+        if (caps && Array.isArray(caps.input_modalities)) return caps.input_modalities.indexOf("image") >= 0;
+        return /v/i.test(id || "");
+      }
       function syncAttachVisibility() { attachBtn.hidden = !isVisionModel(modelSel.value); }
 
       // =========================================================
@@ -806,8 +833,13 @@
         return body;
       }
       function isReasoningModel(id) {
-        // reasoning_effort is only honored by GLM-5.2 and above per BigModel docs.
-        return /glm-5\.[2-9]|glm-[6-9]/i.test(id || "");
+        var caps = getModelCapabilities(id);
+        if (caps && typeof caps.reasoning === "boolean") return caps.reasoning;
+        return /glm-4\.7(?:-flash)?|glm-5\.[2-9]|glm-[6-9]/i.test(id || "");
+      }
+      function isThinkingRequired(id) {
+        var caps = getModelCapabilities(id);
+        return !!(caps && caps.thinking_required === true);
       }
       // =========================================================
       // MCP — client-managed (browser-direct, optional CORS proxy).
@@ -1019,7 +1051,7 @@
         if (!text && pendingImages.length === 0) return;
         // Block image input for non-vision models with a clear message.
         if (pendingImages.length && !isVisionModel(state.settings.model)) {
-          toast("This model does not support image input. Select a vision model (name contains 'v', e.g. glm-4.6v).");
+          toast("This model does not support image input. Select a model marked as image-capable.");
           return;
         }
         var c = activeConv(); if (!c) { newConv(); c = activeConv(); }
@@ -1339,11 +1371,9 @@
           pendingImages = []; renderAttachPreview();
           toast("Switched to a non-vision model \u2014 attached images were removed.");
         }
-        saveState(); syncAttachVisibility(); populateEffort();
+        saveState(); syncAttachVisibility(); syncThinkButton();
       };
-      // GLM-5.2 only has two distinct reasoning-effort levels (low/medium map
-      // to high, xhigh maps to max), so expose just high and max. Other models
-      // get a disabled placeholder (reasoning_effort is GLM-5.2+ only).
+      // Expose the useful high/max effort levels for catalog reasoning models.
       function populateEffort() {
         var model = modelSel.value;
         effortSel.innerHTML = "";
@@ -1355,7 +1385,7 @@
           });
           var cur = state.settings.reasoningEffort;
           effortSel.value = (cur === "high") ? "high" : "max";
-          effortSel.disabled = !state.settings.thinkingEnabled;
+          effortSel.disabled = isThinkingRequired(model) ? false : !state.settings.thinkingEnabled;
         } else {
           var o = document.createElement("option");
           o.value = ""; o.textContent = "n/a";
@@ -1364,10 +1394,13 @@
         }
       }
       function syncThinkButton() {
+        var required = isThinkingRequired(modelSel.value);
+        if (required) state.settings.thinkingEnabled = true;
         var on = state.settings.thinkingEnabled;
         btnThink.classList.toggle("on", on);
         btnThink.textContent = on ? "Think: on" : "Think: off";
-        btnThink.title = on ? "Deep thinking on \u2014 click to turn off" : "Deep thinking off \u2014 click to turn on";
+        btnThink.disabled = required;
+        btnThink.title = required ? "Thinking is required for this model" : (on ? "Deep thinking on \u2014 click to turn off" : "Deep thinking off \u2014 click to turn on");
         // Repopulate so the effort dropdown's disabled state tracks the toggle
         // (populateEffort sets disabled = !thinkingEnabled for reasoning models).
         populateEffort();
@@ -1377,6 +1410,7 @@
         saveState();
       };
       btnThink.onclick = function () {
+        if (isThinkingRequired(modelSel.value)) return;
         state.settings.thinkingEnabled = !state.settings.thinkingEnabled;
         saveState(); syncThinkButton();
       };
@@ -1392,7 +1426,7 @@
         composer.addEventListener(ev, function (e) { e.preventDefault(); composer.style.borderColor = ""; });
       });
       composer.addEventListener("drop", function (e) {
-        if (!isVisionModel(modelSel.value)) { toast("Select a vision model (name contains 'v') to attach images."); return; }
+        if (!isVisionModel(modelSel.value)) { toast("Select a model marked as image-capable to attach images."); return; }
         if (e.dataTransfer && e.dataTransfer.files) readImages(e.dataTransfer.files);
       });
 

--- a/src/translator/anthropic-to-openai.ts
+++ b/src/translator/anthropic-to-openai.ts
@@ -176,6 +176,11 @@ function translateMessageAnthropicToOpenAI(m: AnthropicMessage): OpenAIMessage[]
             type: "image_url",
             image_url: { url: `data:${block.source.media_type};base64,${block.source.data}` },
           });
+        } else if (block.source.type === "url") {
+          contentParts.push({
+            type: "image_url",
+            image_url: { url: block.source.url },
+          });
         }
         break;
       }

--- a/src/translator/openai-to-anthropic.test.ts
+++ b/src/translator/openai-to-anthropic.test.ts
@@ -65,6 +65,38 @@ describe("translateRequestOpenAIToAnthropic", () => {
     expect(result.max_tokens).toBe(2048);
   });
 
+  it("translates ordinary user image parts to Anthropic image blocks", () => {
+    const req: OpenAIChatRequest = {
+      model: "glm-5.3-flash",
+      messages: [{
+        role: "user",
+        content: [
+          { type: "text", text: "What is this?" },
+          { type: "image_url", image_url: { url: "data:image/png;base64,iVBORw0KGgo=" } },
+        ],
+      }],
+    };
+    const result = translateRequestOpenAIToAnthropic(req);
+    expect(result.messages[0].content).toEqual([
+      { type: "text", text: "What is this?" },
+      { type: "image", source: { type: "base64", media_type: "image/png", data: "iVBORw0KGgo=" } },
+    ]);
+  });
+
+  it("preserves remote image URLs as Anthropic image sources", () => {
+    const req: OpenAIChatRequest = {
+      model: "glm-5.3-flash",
+      messages: [{
+        role: "user",
+        content: [{ type: "image_url", image_url: { url: "https://example.com/image.png" } }],
+      }],
+    };
+    const result = translateRequestOpenAIToAnthropic(req);
+    expect(result.messages[0].content).toEqual([
+      { type: "image", source: { type: "url", url: "https://example.com/image.png" } },
+    ]);
+  });
+
   it("translates stop to stop_sequences", () => {
     const req: OpenAIChatRequest = {
       model: "glm-4.6",
@@ -322,7 +354,7 @@ describe("translateRequestOpenAIToAnthropic", () => {
     expect(inner[1].source).toEqual({ type: "base64", media_type: "image/png", data: "iVBORw0KGgo=" });
   });
 
-  it("falls back to text block for non-data: image URLs in tool results (does not silently drop)", () => {
+  it("preserves remote image URLs in tool results", () => {
     const req: OpenAIChatRequest = {
       model: "glm-4.6",
       messages: [
@@ -347,8 +379,10 @@ describe("translateRequestOpenAIToAnthropic", () => {
     expect(Array.isArray(inner)).toBe(true);
     expect(inner).toHaveLength(2);
     expect(inner[0].type).toBe("text");
-    expect(inner[1].type).toBe("text");
-    expect(inner[1].text).toContain("https://example.com/img.png");
+    expect(inner[1]).toEqual({
+      type: "image",
+      source: { type: "url", url: "https://example.com/img.png" },
+    });
   });
 
   it("preserves message order and alternation: user → assistant → user (tool_result) → assistant", () => {
@@ -380,7 +414,29 @@ describe("translateRequestOpenAIToAnthropic", () => {
     expect(result.thinking).toEqual({ type: "enabled" });
   });
 
-  it("does not enable Anthropic thinking by default for non-reasoning GLM models", () => {
+  it("enables Anthropic thinking by default for GLM-4.7-Flash", () => {
+    const req: OpenAIChatRequest = {
+      model: "glm-4.7-flash",
+      messages: [{ role: "user", content: "Hi" }],
+      reasoning_effort: "high",
+    };
+
+    const result = translateRequestOpenAIToAnthropic(req);
+    expect(result.thinking).toEqual({ type: "enabled" });
+  });
+
+  it("keeps thinking enabled for GLM-5.3-Flash when a client tries to disable it", () => {
+    const req = {
+      model: "glm-5.3-flash",
+      messages: [{ role: "user", content: "Hi" }],
+      reasoning_effort: "none",
+      thinking: { type: "disabled" },
+    } as OpenAIChatRequest;
+    const result = translateRequestOpenAIToAnthropic(req);
+    expect(result.thinking).toEqual({ type: "enabled" });
+  });
+
+ it("does not enable Anthropic thinking by default for non-reasoning GLM models", () => {
     const req: OpenAIChatRequest = {
       model: "glm-4.5",
       messages: [{ role: "user", content: "Hi" }],

--- a/src/translator/openai-to-anthropic.ts
+++ b/src/translator/openai-to-anthropic.ts
@@ -14,7 +14,7 @@ import type {
   AnthropicToolDefinition,
   AnthropicThinkingConfig,
 } from "./types.js";
-import { MODELS } from "../provider/models.js";
+import { isReasoningModel, isThinkingRequired } from "../provider/models.js";
 
 /** Default max_tokens if the OpenAI request doesn't specify one. */
 const DEFAULT_MAX_TOKENS = 4096;
@@ -56,6 +56,21 @@ export function translateRequestOpenAIToAnthropic(req: OpenAIChatRequest): Anthr
 
 function translateThinking(req: OpenAIChatRequest): AnthropicThinkingConfig | undefined {
   const explicit = req.thinking;
+
+  // GLM-5.3-Flash requires thinking; normalize attempts to disable or use an
+  // unsupported adaptive mode to the provider's accepted enabled shape.
+  if (isThinkingRequired(req.model)) {
+    const budget = explicit && typeof explicit === "object"
+      ? explicit.budget_tokens ?? explicit.budgetTokens
+      : undefined;
+    return {
+      type: "enabled",
+      ...(typeof budget === "number" && Number.isFinite(budget) && budget > 0
+        ? { budget_tokens: Math.floor(budget) }
+        : {}),
+    };
+  }
+
   if (explicit && typeof explicit === "object") {
     if (explicit.type === "disabled") return { type: "disabled" };
     if (explicit.type === "enabled" || explicit.type === "adaptive") {
@@ -74,10 +89,6 @@ function translateThinking(req: OpenAIChatRequest): AnthropicThinkingConfig | un
   if (req.reasoning_effort === "none") return { type: "disabled" };
   if (isReasoningModel(req.model)) return { type: "enabled" };
   return undefined;
-}
-
-function isReasoningModel(model: string): boolean {
-  return MODELS.some((m) => m.id === model && m.reasoning === true);
 }
 
 function translateToolChoice(
@@ -164,20 +175,7 @@ function toolResultContent(msg: OpenAIMessage): string | AnthropicContentBlock[]
     const joined = msg.content.map((c) => c.text ?? "").join("");
     return joined;
   }
-  return msg.content.map((c) => {
-    if (c.type === "text") return { type: "text" as const, text: c.text ?? "" };
-    if (c.type === "image_url" && c.image_url) {
-      const parsed = parseDataUrl(c.image_url.url);
-      if (parsed) {
-        return {
-          type: "image" as const,
-          source: { type: "base64" as const, media_type: parsed.mediaType, data: parsed.data },
-        };
-      }
-      return { type: "text" as const, text: c.image_url.url };
-    }
-    return { type: "text" as const, text: "" };
-  });
+  return msg.content.map(translateOpenAIContentPart);
 }
 
 function parseDataUrl(url: string): { mediaType: string; data: string } | undefined {
@@ -247,13 +245,27 @@ function extractText(msg: OpenAIMessage): string {
 function translateContentOpenAIToAnthropic(msg: OpenAIMessage): string | AnthropicContentBlock[] {
   if (typeof msg.content === "string") return msg.content;
   if (msg.content === null) return "";
-  if (Array.isArray(msg.content)) {
-    return msg.content.map((c) => {
-      if (c.type === "text") return { type: "text" as const, text: c.text ?? "" };
-      return { type: "text" as const, text: "" };
-    });
-  }
+  if (Array.isArray(msg.content)) return msg.content.map(translateOpenAIContentPart);
   return "";
+}
+
+/** Convert an OpenAI content part without silently dropping image input. */
+function translateOpenAIContentPart(part: { type: "text" | "image_url"; text?: string; image_url?: { url: string; detail?: string } }): AnthropicContentBlock {
+  if (part.type === "text") return { type: "text", text: part.text ?? "" };
+  const url = part.image_url?.url ?? "";
+  const parsed = parseDataUrl(url);
+  if (parsed) {
+    return {
+      type: "image",
+      source: { type: "base64", media_type: parsed.mediaType, data: parsed.data },
+    };
+  }
+  if (/^https?:\/\//i.test(url)) {
+    return { type: "image", source: { type: "url", url } };
+  }
+  // Preserve malformed/unsupported image references as text rather than
+  // turning them into an empty content block.
+  return { type: "text", text: url };
 }
 
 function translateToolOpenAIToAnthropic(tool: OpenAIToolDefinition): AnthropicToolDefinition {

--- a/src/translator/types.ts
+++ b/src/translator/types.ts
@@ -146,12 +146,22 @@ export interface OpenAIStreamChoice {
   finish_reason?: "stop" | "length" | "tool_calls" | "content_filter" | null;
 }
 
+/** Capability metadata attached to `/v1/models` entries. */
+export interface OpenAIModelCapabilities {
+  context_window: number;
+  max_output_tokens?: number;
+  reasoning: boolean;
+  input_modalities: Array<"text" | "image" | "video">;
+  thinking_required?: boolean;
+}
+
 /** /v1/models list entry. */
 interface OpenAIModel {
   id: string;
   object: "model";
   created?: number;
   owned_by: string;
+  capabilities?: OpenAIModelCapabilities;
 }
 
 /** /v1/models list response. */
@@ -167,7 +177,12 @@ export interface OpenAIModelList {
 /** Anthropic content block types. */
 export type AnthropicContentBlock =
   | { type: "text"; text: string }
-  | { type: "image"; source: { type: "base64"; media_type: string; data: string } }
+  | {
+      type: "image";
+      source:
+        | { type: "base64"; media_type: string; data: string }
+        | { type: "url"; url: string };
+    }
   | { type: "tool_use"; id: string; name: string; input: Record<string, unknown> }
   | { type: "tool_result"; tool_use_id: string; content: string | AnthropicContentBlock[]; is_error?: boolean }
   | { type: "thinking"; thinking: string; signature?: string };


### PR DESCRIPTION
## Summary

   - Add `glm-4.7-flash` and `glm-5.3-flash` to the model catalog.
   - Expose model capability metadata through `/v1/models`.
   - Update the WebUI model list and capability detection.
   - Enable reasoning support for `glm-4.7-flash`.
   - Force thinking mode for `glm-5.3-flash`.
   - Preserve OpenAI `image_url` content when translating to Anthropic format.
   - Update configuration templates, documentation, and Android bundle assets.