### PR TITLE
fix(responses): /v1/responses never sent captcha tokens — every start-plan request failed with 3007

### DIFF
--- a/src/proxy/responses-handler.test.ts
+++ b/src/proxy/responses-handler.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect } from "bun:test";
 import { handleResponses } from "./responses-handler.js";
 import { ResponseStore } from "../responses/store.js";
 import type { ProxyConfig } from "../config/types.js";
+import type * as CaptchaExports from "./captcha.js";
+
+type CaptchaModule = typeof CaptchaExports;
 
 const CONFIG: ProxyConfig = {
   server: { port: 0, host: "127.0.0.1" },
@@ -154,5 +157,122 @@ describe("handleResponses", () => {
     expect(continuationUpstreamBody).toContain("first turn");
     expect(continuationUpstreamBody).toContain("turn1");
     expect(continuationUpstreamBody).toContain("second turn");
+  });
+});
+
+// /v1/responses used to skip captcha entirely (it passed `undefined` where
+// handler.ts passes captcha headers), so every start-plan request came back as
+// HTTP 400 {"code":3007,"msg":"captcha verify failed"} while the OpenAI and
+// Anthropic routes worked.
+describe("handleResponses captcha (start-plan)", () => {
+  const START_PLAN: ProxyConfig = { ...CONFIG, plan: "start-plan", provider: "bigmodel" };
+  const PARAM_HEADER = "x-aliyun-captcha-verify-param";
+  const REGION_HEADER = "x-aliyun-captcha-verify-region";
+
+  /** Fake captcha module: mints sequential tokens, records how many were asked for. */
+  function fakeCaptcha(): { module: CaptchaModule; minted: () => number } {
+    let n = 0;
+    const module = {
+      RETRY_HEADERS: { PARAM: PARAM_HEADER, REGION: REGION_HEADER },
+      getCaptchaToken: async () => {
+        n += 1;
+        return { verifyParam: `token-${n}`, region: "cn" };
+      },
+      detectCaptchaChallenge: (resp: Response) => resp.headers.get(PARAM_HEADER),
+    } as unknown as CaptchaModule;
+    return { module, minted: () => n };
+  }
+
+  it("sends a captcha token upstream on start-plan", async () => {
+    const seen: (string | null)[] = [];
+    const fetchImpl = (async (request: Request): Promise<Response> => {
+      seen.push(request.headers.get(PARAM_HEADER));
+      return new Response(anthropicMsg("ok"), { status: 200, headers: { "content-type": "application/json" } });
+    }) as unknown as typeof fetch;
+
+    const captcha = fakeCaptcha();
+    const resp = await handleResponses(makeReq({ model: "glm-5.2", input: "hi" }), {
+      config: START_PLAN, auth, fetchImpl, captcha: captcha.module,
+    });
+    expect(resp.status).toBe(200);
+    expect(seen).toEqual(["token-1"]);
+    expect(captcha.minted()).toBe(1);
+  });
+
+  it("retries once with a fresh token when upstream answers in-body 3007", async () => {
+    const seen: (string | null)[] = [];
+    const fetchImpl = (async (request: Request): Promise<Response> => {
+      seen.push(request.headers.get(PARAM_HEADER));
+      if (seen.length === 1) {
+        return new Response(JSON.stringify({ code: 3007, msg: "captcha verify failed" }), {
+          status: 400, headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response(anthropicMsg("recovered"), { status: 200, headers: { "content-type": "application/json" } });
+    }) as unknown as typeof fetch;
+
+    const captcha = fakeCaptcha();
+    const resp = await handleResponses(makeReq({ model: "glm-5.2", input: "hi" }), {
+      config: START_PLAN, auth, fetchImpl, captcha: captcha.module,
+    });
+    expect(resp.status).toBe(200);
+    const body = await resp.json();
+    expect(body.output[0].content[0].text).toBe("recovered");
+    // The challenged token is already spent, so the retry must carry a NEW one.
+    expect(seen).toEqual(["token-1", "token-2"]);
+  });
+
+  it("retries when the challenge arrives as a response header", async () => {
+    const seen: (string | null)[] = [];
+    const fetchImpl = (async (request: Request): Promise<Response> => {
+      seen.push(request.headers.get(PARAM_HEADER));
+      if (seen.length === 1) {
+        return new Response("denied", { status: 403, headers: { [PARAM_HEADER]: "challenge-abc" } });
+      }
+      return new Response(anthropicMsg("ok"), { status: 200, headers: { "content-type": "application/json" } });
+    }) as unknown as typeof fetch;
+
+    const captcha = fakeCaptcha();
+    const resp = await handleResponses(makeReq({ model: "glm-5.2", input: "hi" }), {
+      config: START_PLAN, auth, fetchImpl, captcha: captcha.module,
+    });
+    expect(resp.status).toBe(200);
+    expect(seen).toEqual(["token-1", "token-2"]);
+  });
+
+  it("gives up after one retry instead of looping", async () => {
+    let calls = 0;
+    const fetchImpl = (async (): Promise<Response> => {
+      calls += 1;
+      return new Response(JSON.stringify({ code: 3007, msg: "captcha verify failed" }), {
+        status: 400, headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const captcha = fakeCaptcha();
+    const resp = await handleResponses(makeReq({ model: "glm-5.2", input: "hi" }), {
+      config: START_PLAN, auth, fetchImpl, captcha: captcha.module,
+    });
+    expect(calls).toBe(2);
+    expect(resp.status).toBe(400);
+    const body = await resp.json();
+    expect(body.error.type).toBe("upstream_error");
+    expect(body.error.message).toContain("3007");
+  });
+
+  it("does not touch captcha on coding-plan", async () => {
+    const seen: (string | null)[] = [];
+    const fetchImpl = (async (request: Request): Promise<Response> => {
+      seen.push(request.headers.get(PARAM_HEADER));
+      return new Response(anthropicMsg("ok"), { status: 200, headers: { "content-type": "application/json" } });
+    }) as unknown as typeof fetch;
+
+    const captcha = fakeCaptcha();
+    const resp = await handleResponses(makeReq({ model: "glm-5.2", input: "hi" }), {
+      config: CONFIG, auth, fetchImpl, captcha: captcha.module,
+    });
+    expect(resp.status).toBe(200);
+    expect(seen).toEqual([null]);
+    expect(captcha.minted()).toBe(0);
   });
 });

--- a/src/proxy/responses-handler.ts
+++ b/src/proxy/responses-handler.ts
@@ -21,7 +21,18 @@ import { transformRequestBody } from "./body-transformer.js";
 import { getProvider } from "../provider/providers.js";
 import type { ProxyConfig } from "../config/types.js";
 import type { AuthManager } from "../auth/manager.js";
-import { buildUpstreamRequest, buildUpstreamHeaderPairs } from "./upstream.js";
+import { buildUpstreamRequest, buildUpstreamHeaderPairs, type UpstreamHeaderPair } from "./upstream.js";
+import type * as CaptchaExports from "./captcha.js";
+
+// Lazy, runtime-gated module load (exception to the static-import rule, same
+// as handler.ts): pulling captcha.ts eagerly drags in the happy-dom solver, so
+// only start-plan — the one plan whose upstream is captcha-gated — pays for it.
+type CaptchaModule = typeof CaptchaExports;
+let captchaModule: CaptchaModule | null = null;
+async function loadCaptcha(): Promise<CaptchaModule> {
+  if (!captchaModule) captchaModule = await import("./captcha.js");
+  return captchaModule;
+}
 import { getDefaultEndpointRouting, type EndpointRoutingService } from "./endpoint-routing.js";
 import { getDefaultClientSigning, sendWithClientSigning, type ClientSigningManager } from "./client-signing.js";
 import { credentialString } from "../auth/types.js";
@@ -64,6 +75,8 @@ export interface ResponsesHandlerOptions {
   endpointRouting?: EndpointRoutingService | null;
   /** Override the process-wide client signing manager (for testing). `null` disables. */
   clientSigning?: ClientSigningManager | null;
+  /** Override the lazily-imported captcha module (for testing). */
+  captcha?: CaptchaModule;
 }
 
 /** Handle POST /v1/responses. */
@@ -166,22 +179,35 @@ export async function handleResponses(
   const transformedBody = upstreamRequestBody;
 
   // ── 6. POST upstream ──
-  const upstreamHeaders = buildUpstreamHeaderPairs(clientReq, upstreamFormat, cred, opts.config.identity, opts.config.plan, undefined, undefined);
-  const upstreamReq = buildUpstreamRequest(clientReq, upstreamFormat, providerDef, cred, transformedBody, opts.config.identity, opts.config.plan, undefined, undefined);
+  // start-plan gates every upstream call behind an Aliyun captcha token. The
+  // Anthropic/OpenAI routes mint one in handler.ts; /v1/responses did not, so
+  // start-plan users got {"code":3007,"msg":"captcha verify failed"} surfaced
+  // as HTTP 400 upstream_error on every request.
+  let captchaHeaders: Record<string, string> | undefined;
+  if (startPlan) {
+    try {
+      const captcha = opts.captcha ?? (await loadCaptcha());
+      const token = await captcha.getCaptchaToken(opts.config.identity.appVersion);
+      captchaHeaders = { [captcha.RETRY_HEADERS.PARAM]: token.verifyParam, [captcha.RETRY_HEADERS.REGION]: token.region };
+    } catch {
+      // Fall through: the 3007 retry below solves on demand.
+    }
+  }
+  const upstreamHeaders = buildUpstreamHeaderPairs(clientReq, upstreamFormat, cred, opts.config.identity, opts.config.plan, captchaHeaders, undefined);
+  const upstreamReq = buildUpstreamRequest(clientReq, upstreamFormat, providerDef, cred, transformedBody, opts.config.identity, opts.config.plan, captchaHeaders, undefined);
   if (debug) console.log(`[responses] → POST ${upstreamReq.url}`);
 
-  let upstreamResp: Response;
-  try {
-    const routing = opts.endpointRouting !== undefined ? opts.endpointRouting : getDefaultEndpointRouting(opts.config);
+  const routing = opts.endpointRouting !== undefined ? opts.endpointRouting : getDefaultEndpointRouting(opts.config);
+  const signer = opts.clientSigning !== undefined ? opts.clientSigning : getDefaultClientSigning(opts.config);
+  const dispatch = async (pairs: UpstreamHeaderPair[]): Promise<Response> => {
     const routed = routing ? await routing.resolve(upstreamReq.url, credentialString(cred)) : null;
     const sendUrl = routed?.routed ? routed.url : upstreamReq.url;
     if (debug && routed?.routed) console.log(`[responses] endpoint routing: ${upstreamReq.url} -> ${sendUrl}`);
-    const signer = opts.clientSigning !== undefined ? opts.clientSigning : getDefaultClientSigning(opts.config);
     // signing decisions run against the PRE-routing provider URL (mirrors the
     // client, whose signer wraps the routing transport)
-    upstreamResp = await sendWithClientSigning(signer, {
+    return sendWithClientSigning(signer, {
       url: upstreamReq.url,
-      headerPairs: upstreamHeaders,
+      headerPairs: pairs,
       credential: credentialString(cred),
       appVersion: opts.config.identity.appVersion,
       debug: debug ? (message) => console.log(`[responses] ${message}`) : undefined,
@@ -194,8 +220,42 @@ export async function handleResponses(
         return fetchImpl(req, { method: "POST", headers: Object.fromEntries(finalPairs), body: transformedBody ?? undefined, signal: clientReq.signal });
       },
     });
+  };
+
+  let upstreamResp: Response;
+  try {
+    upstreamResp = await dispatch(upstreamHeaders);
   } catch (err) {
     return errorResponse(502, "upstream_unreachable", (err as Error).message);
+  }
+
+  // Captcha challenge retry (mirrors handler.ts): the gateway signals it either
+  // through the captcha response header or as HTTP 400 with {"code":3007} in
+  // the body. The challenged token is already spent, so retry once with a fresh
+  // pooled one.
+  if (startPlan && !upstreamResp.ok) {
+    const captcha = opts.captcha ?? (await loadCaptcha());
+    let challenged = captcha.detectCaptchaChallenge(upstreamResp) !== null;
+    if (!challenged && !upstreamResp.headers.get("content-type")?.includes("text/event-stream")) {
+      const peek = await upstreamResp.clone().text().catch(() => "");
+      challenged = peek.includes('"code":3007') || peek.includes('"code": 3007');
+    }
+    if (challenged) {
+      if (debug) console.log("[responses] captcha challenge — re-solving and retrying once");
+      try { await upstreamResp.body?.cancel(); } catch { /* already drained */ }
+      try {
+        const fresh = await captcha.getCaptchaToken(opts.config.identity.appVersion);
+        const retryHeaders = {
+          [captcha.RETRY_HEADERS.PARAM]: fresh.verifyParam,
+          [captcha.RETRY_HEADERS.REGION]: fresh.region,
+        };
+        upstreamResp = await dispatch(
+          buildUpstreamHeaderPairs(clientReq, upstreamFormat, cred, opts.config.identity, opts.config.plan, retryHeaders, undefined),
+        );
+      } catch (err) {
+        return errorResponse(503, "captcha_solver_failed", (err as Error).message);
+      }
+    }
   }
 
   if (!upstreamResp.ok) {


### PR DESCRIPTION
## 问题

`/v1/responses` 完全没有接入验证码层。它在 `handler.ts` 传验证码头的位置传了 `undefined`：

```js
// src/proxy/responses-handler.ts（修复前）
const upstreamHeaders = buildUpstreamHeaderPairs(..., opts.config.plan, undefined, undefined);
const upstreamReq     = buildUpstreamRequest(...,  opts.config.plan, undefined, undefined);
```

对比 `handler.ts:159-172`，那里会先 `getCaptchaToken()` 再注入 `x-aliyun-captcha-verify-param` / `-region`。

start-plan 下上游对**每一个**调用都做验证码校验，所以 `/v1/responses` 必然失败：

```
HTTP 400 {"error":{"type":"upstream_error",
          "message":"{\"code\":3007,\"msg\":\"captcha verify failed\"}"}}
```

而同一进程、同一凭证下 `/v1/messages` 和 `/v1/chat/completions` 完全正常 —— 因为 `handler.ts` 给它们铸了令牌。

这个组合（**只在 start-plan、只在这一条路由**）很容易被误判成求解器故障或指纹问题：本地求解成功、令牌校验通过、其他路由都好，唯独这条 400。实际上是少了调用点。`grep -c captcha src/proxy/responses-handler.ts` 修复前为 `0`。

## 改动

严格对齐 `handler.ts` 的既有模式，不引入新抽象：

- **发前铸币**：`plan === "start-plan"` 时取一枚池中令牌注入请求头，沿用同样的惰性 `import("./captcha.js")`，coding-plan 进程仍然不会加载 happy-dom 求解器。
- **3007 重试一次**：双通道检测，与 `handler.ts` 一致 —— 验证码响应头，以及 HTTP 400 + body 内 `{"code":3007}` 这个变体。被挑战的令牌已被消耗，所以重试必须带**新**令牌。
- **提取 `dispatch(pairs)`**：首发与重试共用同一条 endpoint-routing + client-signing 链路，避免把那段逻辑抄第二遍。
- **新增 `captcha?` 注入口**：与文件里已有的 `fetchImpl` / `endpointRouting` / `clientSigning` 测试注入口并列，让测试无需联网即可覆盖这些路径。

## 验证

- `bun test`：**708 pass / 0 fail**；`bun x tsc --noEmit` 干净。
- 新增 5 个测试（注入假 captcha 模块，零网络、确定性）：
  - start-plan 请求确实带上令牌
  - in-body `{"code":3007}` 触发重试，且重试携带的是**新**令牌（`token-1` → `token-2`）
  - 响应头形式的挑战同样触发重试
  - **只重试一次**，第二次仍失败则如实上抛 `upstream_error`（防止无限循环）
  - coding-plan 完全不碰验证码（不铸币、不加头）
- 反向验证：把验证码头改回 `undefined`，其中 3 个测试立即失败。

> 环境：Bun 1.4.0 / linux-x64。此 PR 与 #37 相互独立（不同文件，无重叠），可单独合并。
