### PR TITLE
fix(captcha): 墓碑到期后留惰性存根，不再硬删全局

### DIFF
--- a/src/proxy/captcha-happy.test.ts
+++ b/src/proxy/captcha-happy.test.ts
@@ -225,6 +225,25 @@ describe("alias lifecycle (install/remove descriptor contract)", () => {
     expect(g.navigator).toBe(hostNavigator);
   });
 
+  test("an expired tombstone leaves callable stubs, never a ReferenceError", async () => {
+    // The grace period ends, but guest stragglers can still be running: the
+    // FeiLin heartbeat `tE` re-arms itself every 2s and dereferences `moveBy`
+    // (feilin008.js:169658). A hard `delete` turned that read into an
+    // uncaught ReferenceError — fatal in the host realm, and the field crash
+    // this guards. The name must stay resolvable and callable.
+    const { g, w } = makeSandbox();
+    (w as Record<string, unknown>).moveBy = () => {};
+    installGlobalWindowAlias(g, w, 15);
+    removeGlobalWindowAlias(g, w);
+    // Real elapsed time is the mechanism under test: the tombstone is a
+    // wall-clock grace period armed on the pristine host setTimeout.
+    await Bun.sleep(70);
+    expect(typeof g.moveBy).toBe("function");
+    expect(() => (g.moveBy as () => void)()).not.toThrow();
+    // The stub must not keep the closed window reachable from globalThis.
+    expect(g.moveBy).not.toBe((w as Record<string, unknown>).moveBy);
+  });
+
   test("a new install cancels the pending tombstone", async () => {
     const { g, w } = makeSandbox();
     const w2: Record<string, unknown> = {

--- a/src/proxy/captcha-happy.ts
+++ b/src/proxy/captcha-happy.ts
@@ -1807,6 +1807,12 @@ const EXTRA_WINDOW_PROPS = [
   "prompt", "getSelection", "find",
 ];
 
+// Subset of the above that a real browser implements as no-op-ish window
+// methods. When the tombstone expires these become harmless stubs instead of
+// being deleted, so a straggling guest callback that still calls `moveBy()`
+// completes silently rather than raising a fatal ReferenceError.
+const INERT_WINDOW_METHODS = new Set(EXTRA_WINDOW_PROPS);
+
 // Ref-count: the pool solves in parallel waves; each window must keep the
 // aliases alive until the LAST concurrent window is destroyed, otherwise one
 // destroyDom() pulls `window` out from under a sibling mid-solve.
@@ -2124,7 +2130,19 @@ export function removeGlobalWindowAlias(g, w) {
       if (generation !== _aliasGeneration || _aliasRefCount > 0) return;
       for (const name of names) {
         try {
-          if (Object.getOwnPropertyDescriptor(g, name)?.get) delete g[name];
+          if (!Object.getOwnPropertyDescriptor(g, name)?.get) continue;
+          // Do NOT `delete`: a straggler still reading the name would get a
+          // ReferenceError, which is fatal in the host realm. Leave an inert
+          // value instead — the reference resolves, the call is a no-op, and
+          // nothing keeps the closed window alive. The window methods guest
+          // fingerprint code probes (moveBy/scrollTo/...) are no-ops in a real
+          // browser anyway, so `undefined` is a faithful stand-in for the rest.
+          const stub = INERT_WINDOW_METHODS.has(name) ? () => {} : undefined;
+          Object.defineProperty(g, name, {
+            value: stub,
+            configurable: true,
+            writable: true,
+          });
         } catch (_) {}
       }
     }, _tombstoneMs);


### PR DESCRIPTION
### 背景

v4.5.5 TUI 模式下反复崩溃（实际使用中间隔 2m47s / 14m37s / 27m15s / 29m15s）：

```
zcode-proxy: tui crashed: ReferenceError: moveBy is not defined
    at tE (https://g.alicdn.com/captcha-frontend/FeiLin/1.5.1/feilin008….js:1:169658)
```

崩溃链条：

1. FeiLin 的 `tE` 是个 2 秒心跳，会自我重新武装（feilin008.js:170382 `tV=setInterval(tE,2e3)`）
2. 它 arm 的定时器错误地落在宿主车道，`happyDOM.close()` 收不走 → 不朽定时器
3. **30 秒后墓碑 `delete` 掉 `moveBy`，心跳下次触发即 `ReferenceError`**
4. TUI 的 `uncaughtException` 处理器对一切 `exit(1)` → 代理进程死亡

**本 PR 切断第 3 环**，与其余三个 PR 互不依赖，可单独合入。

---

### 问题

5fcb778 给 window 类全局加了 30 秒宽限期，让滞留的 FeiLin 指纹回调能平稳落地（feilin005.js 的 `Text is not defined`）。方向是对的。

但宽限期结束时**仍然是 `delete`**，所以它推迟了崩溃而没有消除崩溃：活得比 30 秒更久的残留回调，照样把一次全局读取变成 `uncaughtException`。

FeiLin 的心跳恰好属于这一类 —— 它每 2 秒重新武装自己，函数体里读 `moveBy`：

```js
// feilin008.js:169658，tE 函数体内
Math.pow(!navigator*!moveBy, 0) ? r -= 1 : r += -6
```

只要这个心跳还活着，宽限期一到就是必然崩溃，只是把时刻从「拆解瞬间」推到了「拆解后 30 秒」。这与现场观测到的崩溃间隔分布一致。

---

### 改动

不再 `delete`，而是留下惰性值：

- `EXTRA_WINDOW_PROPS` 里的窗口方法（`moveBy`/`scrollTo`/…）留一个 no-op —— 真实浏览器里它们本来也几乎是 no-op
- 其余名字留 `undefined`

引用得以解析，调用无害完成。存根不指向已关闭的窗口，因此不会把它钉在 `globalThis` 上。

---

### 验证

让一个不朽心跳持续读 `moveBy` 跨越宽限期：

| | 宽限期内 | 宽限期后 |
|---|---|---|
| 改动前 | 正常 | 每次触发一条 `uncaughtException` |
| 改动后 | 正常 | **0** |

最坏情况下的直接调用也已确认无害：

```
墓碑到期后 typeof moveBy = function
straggler 调用 moveBy()          → 无害完成
FeiLin tE 里的原始表达式         → 无害求值
存根是否指向已关闭窗口            → 否
```

- `bun x tsc --noEmit` 0 错误
- `bun test` 733 pass / 0 fail（上游基线 732，本 PR 新增 1 条回归测试）
