### PR TITLE
fix(captcha): 补上 rAF 别名，并给 getter 探测的 rejected promise 加 sink

### DIFF
--- a/src/proxy/captcha-happy.test.ts
+++ b/src/proxy/captcha-happy.test.ts
@@ -251,3 +251,25 @@ describe("alias lifecycle (install/remove descriptor contract)", () => {
     expect(Object.getOwnPropertyDescriptor(g, "setTimeout")?.get).toBeUndefined();
   });
 });
+
+describe("browser globals the guest SDK dereferences bare", () => {
+  test("requestAnimationFrame/cancelAnimationFrame resolve during a solve", () => {
+    // Bun has no native rAF. While these sat in HOST_CRITICAL_GLOBALS the
+    // alias pass skipped them, so the FeiLin bundle's 9 bare
+    // `requestAnimationFrame` references (only one `typeof`-guarded) were
+    // unresolvable — the same silent fingerprint degradation `print` caused,
+    // visible only as a lower solve rate.
+    const g: Record<string, unknown> = {};
+    const w: Record<string, unknown> = {
+      requestAnimationFrame: (cb: () => void) => 1,
+      cancelAnimationFrame: () => {},
+    };
+    installGlobalWindowAlias(g, w, 15);
+    try {
+      expect(typeof g.requestAnimationFrame).toBe("function");
+      expect(typeof g.cancelAnimationFrame).toBe("function");
+    } finally {
+      removeGlobalWindowAlias(g, w);
+    }
+  });
+});

--- a/src/proxy/captcha-happy.ts
+++ b/src/proxy/captcha-happy.ts
@@ -630,7 +630,13 @@ function installNativeToString(w) {
         try {
           const v = desc.get.call(obj);
           if (typeof v === "function") mask(v);
-        } catch (_) {}
+          // Probing a getter can hand back an already-rejected promise (WHATWG
+          // stream `closed`/`ready` reject when the receiver is the prototype
+          // rather than an instance). Nobody awaits these, so without a sink
+          // each probe surfaced as an unhandledRejection on every solve —
+          // noise that buried real diagnostics.
+          else if (v && typeof v.then === "function") v.catch(() => {});
+        } catch {}
       }
       if (depth < 3) {
         try {
@@ -1774,7 +1780,12 @@ async function createDom(region, prefix) {
 const HOST_CRITICAL_GLOBALS = new Set([
   "process", "Bun", "console", "performance", "crypto", "fetch",
   "queueMicrotask", "structuredClone", "TextEncoder", "TextDecoder",
-  "requestAnimationFrame", "cancelAnimationFrame",
+  // NOTE: requestAnimationFrame/cancelAnimationFrame were removed from this
+  // list (2026-09-06). Bun has no native rAF, so skipping the alias left a
+  // bare `requestAnimationFrame` in the FeiLin bundle unresolvable (9 call
+  // sites, only one `typeof`-guarded) — the same silent fingerprint
+  // degradation that `print` caused. Aliasing the window's implementation
+  // shadows nothing on the host.
   // NOTE: `print` was removed from this list (2026-08-29). The polyfill
   // defines a harmless no-op on the window, but the alias pass skipped it,
   // so under Bun (guest scripts run in the HOST realm) the Aliyun pe risk


### PR DESCRIPTION
### 背景

排查 v4.5.5 TUI 崩溃（`ReferenceError: moveBy is not defined`）时顺带发现的两处独立缺口。两者都**只表现为静默劣化，不产生可见报错**，因此一直没被注意到。

与其余三个 PR 互不依赖，可单独合入。

---

### 1. `requestAnimationFrame` / `cancelAnimationFrame` 移出 `HOST_CRITICAL_GLOBALS`

`HOST_CRITICAL_GLOBALS` 的用意是「别遮蔽宿主依赖的内建」。但 **Bun 根本没有原生 rAF**：

```
Bun globalThis.requestAnimationFrame → undefined
happy-dom window.requestAnimationFrame → function
```

所以跳过别名不是「保护宿主」，而是让它对 guest 完全不可解析。

`feilin008` 里有 **9 处裸引用**，只有 1 处带 `typeof` 保护：

```
464320  (n=12, requestAnimationFrame(function…      ← 无保护
464404  (e-=1, requestAnimationFrame(i))            ← 无保护
464498  u = typeof requestAnimationFrame            ← 有保护
464725  isNaN(!requestAnimationFrame/!request…      ← 无保护
…共 9 处
```

这些调用点落在 Promise executor 内，因此**不会崩溃，只会打断指纹链**，表现为求解成功率下降。实测在解析点装探针，一轮求解命中 24 次，其中来自 `feilin008` 的调用确认在 Promise 构造器内。

这与 2026-08-29 修 `print` 的那次是**同型问题** —— 同一个跳过表、同样的静默劣化、同样的「Bun 宿主没有该全局，别名不遮蔽任何东西」。注释里已引用那次修复。

---

### 2. `installNativeToString` 探测 getter 时产生的 rejected promise 加 sink

`maskObj` 会调用 getter，以便给返回的函数也套上 native `toString` 伪装：

```js
const v = desc.get.call(obj);
if (typeof v === "function") mask(v);
```

WHATWG stream 的 `closed` / `ready` 在接收者是**原型而非实例**时返回一个已拒绝的 promise。没人 await，于是每次求解稳定产出 4 条 `unhandledRejection`：

```
The 'closed' getter can only be used on a ReadableStreamBYOBReader
The 'closed' getter can only be used on a ReadableStreamDefaultReader
The 'closed' getter can only be used on a WritableStreamDefaultWriter
The 'ready'  getter can only be used on a WritableStreamDefaultWriter
```

探测结果本来就是丢弃的，加一个 `.catch(() => {})` 即可。这类噪音会淹没真正需要关注的诊断信息。

---

### 验证

```
别名安装后 bare requestAnimationFrame → function
别名安装后 bare cancelAnimationFrame  → function
完整一轮求解的 unhandledRejection     → 0 条（改动前 4 条 stream getter 噪音）
```

- `bun x tsc --noEmit` 0 错误
- `bun test` 733 pass / 0 fail（上游基线 732，本 PR 新增 1 条 rAF 契约测试）
